### PR TITLE
possible fix for: UnhandledPromiseRejectionWarning: TypeError: Cannot…

### DIFF
--- a/js/web-server.js
+++ b/js/web-server.js
@@ -328,7 +328,8 @@ function setup(req, res, next) {
     if (time - rec.saved > ipSaveDelay) db.get(dbikey)
         .then(dbrec => {
             // only on the first pull from disk
-            if (dbrec && rec.saved === 0) {
+            if (dbrec.first && dbrec.hits && dbrec.last &&
+                    dbrec.api && rec.saved === 0) {
                 rec.first = dbrec.first;
                 rec.hits += dbrec.hits;
                 rec.last = dbrec.last.appendAll(rec.last);


### PR DESCRIPTION
possible fix for: `UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'appendAll' of undefined at db.get.then.dbrec`

To reproduce the problem:
- clone the repo
- `npm update` (I needed to fix levelup for `npm update` to work: https://github.com/GridSpace/grid-apps/pull/37)
- start Kiri:Moto web server with `npm start` **-or-** `npm run-script start-web`
- browsing to http://127.0.0.1:8080/kiri produces errors on the console[1]
- refreshing the page with F5, Ctrl-r, or Ctrl-Shift-r also produces errors on the console[1]
- the error messages are repeated 6 times per page load. [1]

The cause of these specific error messages is that the dbrec.last  array is undefined so the appendAll prototype gets confused. 

In fact all the dbrec values are undefined. When I add this to the block:
console.log('dbrec: '+dbrec);            
console.log('dbrec.first: '+dbrec.first);
console.log('dbrec.hits: '+dbrec.hits);
console.log('dbrec.last: '+dbrec.last);
console.log('dbrec.api: '+dbrec.api);

The results are:
dbrec: [object Object]
dbrec.first: undefined
dbrec.hits: undefined
dbrec.last: undefined
dbrec.api: undefined

So the `if (dbrec)` test succeeds because dbrec is instantiated as an object, even though its values are undefined.

**This may not be the best fix.**
- My change gets rid of the errors, but there may be a use case in which one or more of the values are allowed to be undefined, so perhaps each value should be handled individually.
- The dbrec.first and dbrec.hits value assignments don't complain, so perhaps the Array.prototype.appendAll wrapper should be changed to handle undefined values.
- The comment in this block says `only on the first pull from disk`, so perhaps the dbrec values are **always** undefined and this block is unnecessary and can be removed.

[1]
`
(node:13249) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'appendAll' of undefined
    at db.get.then.dbrec (/home/barry/cnc/gridspace/grid-apps/js/web-server.js:334:39)
(node:13249) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:13249) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
(node:13249) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'appendAll' of undefined
    at db.get.then.dbrec (/home/barry/cnc/gridspace/grid-apps/js/web-server.js:334:39)
(node:13249) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
(node:13249) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'appendAll' of undefined
    at db.get.then.dbrec (/home/barry/cnc/gridspace/grid-apps/js/web-server.js:334:39)
(node:13249) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 3)
(node:13249) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'appendAll' of undefined
    at db.get.then.dbrec (/home/barry/cnc/gridspace/grid-apps/js/web-server.js:334:39)
(node:13249) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 4)
(node:13249) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'appendAll' of undefined
    at db.get.then.dbrec (/home/barry/cnc/gridspace/grid-apps/js/web-server.js:334:39)
(node:13249) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 5)
(node:13249) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'appendAll' of undefined
    at db.get.then.dbrec (/home/barry/cnc/gridspace/grid-apps/js/web-server.js:334:39)
(node:13249) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 6)
`