### PR TITLE
outputTemp: 200

### DIFF
--- a/js/kiri.js
+++ b/js/kiri.js
@@ -293,7 +293,7 @@ self.kiri.license = exports.LICENSE;
                 outputRaft: false,
                 outputRaftSpacing: 0.2,
 
-                outputTemp: 220,
+                outputTemp: 200,
                 outputFanMax: 255,
                 outputBedTemp: 0,
                 outputFeedrate: 80,


### PR DESCRIPTION
At least on my reference printer, the Prusa i3 MK2S, 220 degrees C causes more oozing with PLA than at 200 degrees C (the Prusa default profile specifies 210 degrees C).