### PR TITLE
Fix null pointer dereference when drilling with dwell time

### DIFF
--- a/js/kiri-print.js
+++ b/js/kiri-print.js
@@ -385,7 +385,7 @@ var gs_kiri_print = exports;
      */
     function addOutput(array, point, emit, speed, tool) {
         // drop duplicates (usually intruced by FDM bisections)
-        if (lastPoint && point.x == lastPoint.x && point.y == lastPoint.y && point.z == lastPoint.z && lastEmit == emit) {
+        if (lastPoint && point && point.x == lastPoint.x && point.y == lastPoint.y && point.z == lastPoint.z && lastEmit == emit) {
             return;
         }
         lastPoint = point;


### PR DESCRIPTION
```
Uncaught TypeError: Cannot read property 'x' of null
    at addOutput (v1.2.4b:388)
    at layerPush (v1.2.4b:979)
    at camDwell (v1.2.4b:1057)
    at v1.2.4b:1048
    at Array.forEach (<anonymous>)
    at emitDrill (v1.2.4b:1045)
    at emitDrills (v1.2.4b:1014)
    at Object.printSetup (v1.2.4b:1356)
    at Print.PRO.setup (v1.2.4b:176)
    at printSetup (1.2.4b:1)
```