### PR TITLE
Added Gcode preview feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ tmp
 .DS_Store
 node_modules
 package-lock.json
+logs/*
+data/*

--- a/src/kiri/conf.js
+++ b/src/kiri/conf.js
@@ -619,6 +619,7 @@
                 exportOcto: false,
                 exportGhost: false,
                 exportLocal: true,
+                exportCodePreview: false,
                 decimate: true,
                 detail: "good",
                 animesh: "200"

--- a/src/kiri/export.js
+++ b/src/kiri/export.js
@@ -425,6 +425,9 @@
             let octo = set.controller.exportOcto && MODE !== MODES.CAM;
             let ghost = set.controller.exportGhost;
             let local = set.controller.exportLocal;
+            let codepreview = set.controller.exportCodePreview;
+            $('code-preview-head').style.display = codepreview ? '' : 'none';
+            $('code-preview').style.display = codepreview ? '' : 'none';
             $('print-download').onclick = download;
             $('print-filament-head').style.display = fdm ? '' : 'none';
             $('print-filament-info').style.display = fdm ? '' : 'none';
@@ -485,6 +488,9 @@
                 $('print-gridlocal').onclick = sendto_gridlocal;
                 $('admin-gridlocal').onclick = admin_gridlocal;
             } catch (e) { console.log(e) }
+            
+            // preview of the generated GCODE
+            if (codepreview && gcode) $('code-preview-textarea').value = gcode;
 
             // show dialog
             API.modal.show('print');

--- a/src/kiri/init.js
+++ b/src/kiri/init.js
@@ -144,6 +144,7 @@
         control.exportOcto = UI.exportOcto.checked;
         control.exportGhost = UI.exportGhost.checked;
         control.exportLocal = UI.exportLocal.checked;
+        control.exportCodePreview = UI.exportCodePreview.checked;
         control.decimate = UI.decimate.checked;
         SPACE.view.setZoom(control.reverseZoom, control.zoomSpeed);
         platform.layout();
@@ -1502,6 +1503,7 @@
             exportOcto:       UC.newBoolean(`OctoPrint`, booleanSave),
             exportGhost:      UC.newBoolean(`Grid:Host`, booleanSave),
             exportLocal:      UC.newBoolean(`Grid:Local`, booleanSave),
+            exportCodePreview:    UC.newBoolean(`Code Preview`, booleanSave),
 
             parts:            UC.newGroup(LANG.pt_menu, $('prefs-prt'), {inline: true}),
             detail:           UC.newSelect(LANG.pt_qual_s, {title: LANG.pt_qual_l, action: detailSave}, "detail"),

--- a/web/kiri/index.css
+++ b/web/kiri/index.css
@@ -645,6 +645,11 @@ th, tr, td, label {
 #print-download {
     min-height: 4em !important;
 }
+#code-preview-textarea {
+    width: 100%;
+    height: 250px;
+    font-size: 10px;
+}
 .mod-end {
     height: 10px;
     border-bottom-left-radius: 10px;

--- a/web/kiri/output-gcode.html
+++ b/web/kiri/output-gcode.html
@@ -12,6 +12,11 @@
     <div><label>printed weight (g)</label><input id="print-weight" size="12" disabled="true" /></div>
 </div>
 
+<div id="code-preview-head" class="header"><label>code preview</label></div>
+<div id="code-preview" class="f-col box">
+    <div><textarea id="code-preview-textarea"></textarea></div>
+</div>
+
 <div class="header"><label>gcode</label></div>
 <div class="f-row box">
     <button id="print-download" class="grow">download</button>


### PR DESCRIPTION
Hi, I added a "preview" of the GCODE created in the "export" dialog.
It is a cool improve in my workflow because allows me to check the GCODE before download it (instead of download it, check it, and eventually change something and re-do the slice).
I did this in particular for CNC path, but can be used also for FDM

If this feature was already present (and i wasn't not able to find it) i apologize for this pull request.

The feature can be enabled or disabled in the "application preferences" dialog.
The default value is "disabled".
![Code preview](https://user-images.githubusercontent.com/3313295/100610804-a2473100-3310-11eb-8f99-35904172932e.png)

Here a screenshot of the "export" dialog with the code preview enabled.
![code_preview](https://user-images.githubusercontent.com/3313295/100610868-bee36900-3310-11eb-9032-8ce0ae28e605.png)

