### PR TITLE
Adding Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:15.14.0-stretch
+WORKDIR /app
+COPY ./ /app/
+EXPOSE 8080
+RUN npm i
+RUN npm install -g @gridspace/app-server
+CMD gs-app-server --debug

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3.1'
+
+services:
+  kirimoto:
+    build:
+      context: .
+    ports:
+      - "8080:8080"
+
+
+
+

--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,19 @@ Contributions in all forms (code, bug reports, community engagement, localizatio
 * [Discord Chat](https://discord.com/channels/688863523207774209/688863523211968535)
 * [Wiki Reference](https://github.com/GridSpace/grid-apps/wiki)
 
+### Testing Locally (with Docker)
+
+```
+git clone git@github.com:GridSpace/grid-apps.git
+cd grid-apps
+docker-compose build
+docker-compose up
+```
+
+You can now access your environment of grid-apps by going to:
+[Kiri:Moto](http://127.0.0.1:8080/kiri) or
+[Meta:Moto](http://127.0.0.1:8080/meta).
+
 ### Testing Locally
 
 ```


### PR DESCRIPTION
This pull request adds a Docker file, a docker-compose file, and an updated readme with instructions on how to build the docker image and then run the contained version of grid-apps through docker-compose.

This should hopefully make it easier to deploy and run on Windows, OS X, and Linux.