### PR TITLE
Allow Anycubic i3 Mega to Resume from Outage

### DIFF
--- a/src/dev/fdm/Anycubic.i3.Mega
+++ b/src/dev/fdm/Anycubic.i3.Mega
@@ -19,7 +19,8 @@
         "G1 F100       ; set default feed rate",
         "G0 Y20        ; wipe move to Y20",
         "G92 E0        ; zero extruder",
-        "M117 Printing..."
+        "M117 Printing...",
+        "G5            ; enable resume from outage"
     ],
     "post":[
         "M107                ; turn off fan",


### PR DESCRIPTION
Adds the necessary G-code to allow the Anycubic i3 Mega to resume the print.
This change is shown in page 38 of the manual (https://drive.google.com/file/d/13hGH6_5x4iELyqkURTVaChUewx2xc3V2/view) and also is in the printer's Cura profile (https://github.com/Ultimaker/Cura/blob/master/resources/definitions/anycubic_i3_mega.def.json, https://github.com/Ultimaker/Cura/blob/master/resources/definitions/anycubic_i3_mega_s.def.json).
Also, this is untested because I changed this file manually, and I don't know how to import it.