### PR TITLE
modif cr-10s-pro profil

### DIFF
--- a/src/dev/fdm/Creality.CR-10S-Pro
+++ b/src/dev/fdm/Creality.CR-10S-Pro
@@ -1,0 +1,58 @@
+{
+    "pre":[
+        "M140 S{bed_temp}                       ; Set bed temp",
+        "M105                                   ; Report Temps",
+        "M190 S{bed_temp}                       ; Wait for bed to reach target",
+        "M104 S{temp}                           ; Set hot end temp",
+        "M105                                   ; Report Temps",
+        "M109 S{temp}                           ; Wait for hot end to reach target",
+        "M82                                    ; Absolute extrusion mode",
+        "M201 X500.00 Y500.00 Z100.00 E5000.00  ; Setup machine max acceleration",
+        "M203 X500.00 Y500.00 Z10.00 E50.00     ; Setup machine max feedrate",
+        "M204 P500.00 R1000.00 T500.00          ; Setup Print/Retract/Travel acceleration",
+        "M205 X8.00 Y8.00 Z0.40 E5.00           ; Setup Jerk",
+        "M220 S100                              ; Reset Feedrate",
+        "M221 S100                              ; Reset Flowrate",
+        "G28                                    ; Home",
+        "G29                                    ; Auto bed Level",
+        "G92 E0                                 ; Reset Extruder",
+        "G1 Z2.0 F3000                          ; Move Z Axis up",
+        "G1 X10.1 Y20 Z0.28 F5000.0             ; Move to start position",
+        "G1 X10.1 Y200.0 Z0.28 F1500.0 E15      ; Draw the first line",
+        "G1 X10.4 Y200.0 Z0.28 F5000.0          ; Move to side a little",
+        "G1 X10.4 Y20 Z0.28 F1500.0 E30         ; Draw the second line",
+        "G92 E0                                 ; Reset Extruder",
+        "G1 Z2.0 F3000                          ; Move Z Axis up",
+        "G92 E0                                 ; Reset Extruder"
+    ],
+    "post":[
+        "M107                                   ; Turn off cooling fan",
+        "G91                                    ; Relative positioning",
+        "G1 E-2 F2700                           ; Retract",
+        "G1 Z10                                 ; Raise Z",
+        "G90                                    ; Absolute positioning",
+        "G1 X0 Y300                             ; Eject print",
+        "M104 S0                                ; Turn-off hot end",
+        "M140 S0                                ; Turn-off bed",
+        "M84 X Y E                              ; Disable steppers except Z"
+    ],
+    "extruders":[
+        {
+            "nozzle": 0.4,
+            "filament": 1.75,
+            "offset_x": 0,
+            "offset_y": 0,
+            "select": [ "T0" ]
+        }
+    ],
+    "cmd":{
+        "fan_power": "M106 S{fan_speed}"
+    },
+    "settings":{
+        "origin_center": false,
+        "extrude_abs": true,
+        "bed_width": 300,
+        "bed_depth": 300,
+        "build_height": 400
+    }
+}

--- a/src/dev/fdm/Creality.CR-10S.Pro
+++ b/src/dev/fdm/Creality.CR-10S.Pro
@@ -1,1 +1,0 @@
-Creality.CR-10S


### PR DESCRIPTION
I changed the fdm "cr-10s pro" profile since it looked like the auto bed leveling gcode line (line 17) was missing in the header.