### PR TITLE
Add @gridspace/app-server as devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,5 +36,11 @@
         "uglify-es": "3.3.9",
         "validator": "^8.2.0",
         "ws": "^7.2.3"
+    },
+    "devDependencies" : {
+        "@gridspace/app-server": "^0.0.7"
+    },
+    "scripts": {
+        "debug": "gs-app-server --debug"
     }
 }


### PR DESCRIPTION
Wouldn't it be a lot easier to add `@gridspace/app-server` as devDependencies so you can use a script to just run `npm run debug` to start the server without having to install it globally?