### PR TITLE
add z thru to drill depth

### DIFF
--- a/src/mode/cam/prepare.js
+++ b/src/mode/cam/prepare.js
@@ -201,7 +201,7 @@
                     break;
                 }
             }
-            camOut(point.clone().setZ(zmax));
+            camOut(point.clone().setZ(zmax + zThru));
             points.forEach(function(point, index) {
                 camOut(point, 1);
                 if (index > 0 && index < points.length - 1) {
@@ -209,7 +209,7 @@
                     if (lift) camOut(point.clone().setZ(point.z + lift), 0);
                 }
             })
-            camOut(point.clone().setZ(zmax));
+            camOut(point.clone().setZ(zmax + zThru));
             newLayer();
         }
 

--- a/web/kiri/lang/de-de.js
+++ b/web/kiri/lang/de-de.js
@@ -511,7 +511,7 @@ kiri.lang['de-de'] = {
     ou_zclr_s:      "z clearance",
     ou_zclr_l:      ["safe travel offset","from top of part","in workspace units"],
     ou_ztru_s:      "z thru",
-    ou_ztru_l:      ["extend cutout pass down","in workspace units"],
+    ou_ztru_l:      ["extend cutout pass down","and increase drill depth","in workspace units"],
     ou_conv_s:      "Gegenlauffräsen",
     ou_conv_l:      ["milling direction","uncheck for 'climb'"],
     ou_depf_s:      "depth first",

--- a/web/kiri/lang/en.js
+++ b/web/kiri/lang/en.js
@@ -553,7 +553,7 @@ kiri.lang['en-us'] = {
     ou_zclr_s:      "z clearance",
     ou_zclr_l:      ["safe travel offset","from top of part","in workspace units"],
     ou_ztru_s:      "z thru",
-    ou_ztru_l:      ["extend cutout pass down","in workspace units"],
+    ou_ztru_l:      ["extend cutout pass down","and increase drill depth","in workspace units"],
     ou_conv_s:      "conventional",
     ou_conv_l:      ["milling direction","uncheck for 'climb'"],
     ou_depf_s:      "depth first",

--- a/web/kiri/lang/fr.js
+++ b/web/kiri/lang/fr.js
@@ -513,7 +513,7 @@ kiri.lang['fr-fr'] = {
     ou_zclr_s:      "z clearance",
     ou_zclr_l:      ["safe travel offset","from top of part","in workspace units"],
     ou_ztru_s:      "z thru",
-    ou_ztru_l:      ["extend cutout pass down","in workspace units"],
+    ou_ztru_l:      ["extend cutout pass down","and increase drill depth","in workspace units"],
     ou_conv_s:      "conventional",
     ou_conv_l:      ["milling direction","uncheck for 'climb'"],
     ou_depf_s:      "depth first",

--- a/web/kiri/lang/pl-pl.js
+++ b/web/kiri/lang/pl-pl.js
@@ -516,7 +516,7 @@ kiri.lang['pl-pl'] = {
     ou_zclr_s:      "z clearance",
     ou_zclr_l:      ["safe travel offset","from top of part","in workspace units"],
     ou_ztru_s:      "z thru",
-    ou_ztru_l:      ["extend cutout pass down","in workspace units"],
+    ou_ztru_l:      ["extend cutout pass down","and increase drill depth","in workspace units"],
     ou_conv_s:      "conventional",
     ou_conv_l:      ["milling direction","uncheck for 'climb'"],
     ou_depf_s:      "depth first",


### PR DESCRIPTION
Take "Z thru" limit, if set, into account when drilling, to ensure holes go through fully.

I think this makes sense and is what people would expect when setting the "Z thru" limit. Until now, only the cutout pass of the outline tool respected that value.

However: I could not test this change yet! Please let me know if it seems reasonable.