### PR TITLE
Allow absolute paths to files in cli.js command line arguments

### DIFF
--- a/src/kiri/cli.js
+++ b/src/kiri/cli.js
@@ -68,7 +68,10 @@ let exports_save = exports,
 // fake fetch for worker to get wasm, if needed
 let fetch = function(url, opts = {}) {
     if (verbose) console.log({fetch: url});
-    let buf = fs.readFileSync(`${dir}/${url}`);
+    if (!url.startsWith('/')) {
+      url = `${dir}/${url}`;
+    }
+    let buf = fs.readFileSync(url);
     return new Promise((resolve, reject) => {
         resolve(new Promise((resolve, reject) => {
             if (opts.format === 'string') {


### PR DESCRIPTION
A quick follow-up to the fix in #199 - this allows specifying absolute paths to input files, e.g.

```
node <redacted>/grid-apps/src/kiri/cli.js \
--process=/home/<user>/.config/kiri/process.json \
--device=/home/<user>/config/kiri/device.json \
--output=/home/<user>Downloads/out.gcode \
--model=/home/user/Documents/input.stl
```

Otherwise,  `dir` gets prepended to them and the file isn't found.