### PR TITLE
Fixed error on npm post install on Docker image build.

### DIFF
--- a/src/dock/Dockerfile
+++ b/src/dock/Dockerfile
@@ -5,7 +5,9 @@ COPY app.js /grid
 COPY apps /grid/apps
 COPY src /grid/src
 COPY web /grid/web
+COPY bin /grid/bin
 EXPOSE 8080
 RUN npm i
 RUN npm install -g @gridspace/app-server
+RUN rm -rf /grid/bin
 CMD gs-app-server


### PR DESCRIPTION
Hi! I try to run **grid-apps** in docker container with provided command in **readme**:
`docker-compose -f src/dock/compose.yml up`
and it fails with error:
```

...
Step 9/11 : RUN npm i
 ---> Running in 5605d674a359
npm WARN deprecated har-validator@5.1.5: this library is no longer supported
npm WARN deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
npm WARN deprecated request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142

> grid-apps@3.7.1D postinstall
> bin/npm-post

sh: 1: bin/npm-post: not found
npm notice
npm notice New major version of npm available! 7.7.6 -> 8.19.2
npm notice Changelog: <https://github.com/npm/cli/releases/tag/v8.19.2>
npm notice Run `npm install -g npm@8.19.2` to update!
npm notice
npm ERR! code 127
npm ERR! path /grid
npm ERR! command failed
npm ERR! command sh -c bin/npm-post

npm ERR! A complete log of this run can be found in:
npm ERR!     /root/.npm/_logs/2022-10-26T16_37_15_014Z-debug.log
The command '/bin/sh -c npm i' returned a non-zero code: 127
ERROR: Service 'kirimoto' failed to build : Build failed
```

This error occurs because there are no **bin/npm-post** in filesystem in container during image build. This pull request fixes that error. Please review it and merge if there are no issues in diffs.