### PR TITLE
Update Dockerfile to node:18-buster lts

### DIFF
--- a/src/dock/Dockerfile
+++ b/src/dock/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:15.14.0-stretch
+FROM node:18-buster
 WORKDIR /grid
 COPY package.json /grid
 COPY app.js /grid


### PR DESCRIPTION
update docker file to use newer nodejs lts container