### PR TITLE
Proof of concept of configurable "Ease-Down" with a slope and start Z

### DIFF
--- a/src/geo/polygon.js
+++ b/src/geo/polygon.js
@@ -1165,13 +1165,13 @@ class Polygon {
                 let deltaZFullMove = dist2next * slope;
 
                 if (deltaZFullMove > deltaZ) {
-                  // Too long: easing along full path would overshoot depth, synth intermediate point at target Z.
-                  //
-                  // XXX: please check my super basic trig - this should follow from `last` to `next` up until the
-                  //      intersect at the target Z distance.
-                  fn(last.followTo(next, dist2next * deltaZ / deltaZFullMove).setZ(next.z), offset++);
+                    // Too long: easing along full path would overshoot depth, synth intermediate point at target Z.
+                    //
+                    // XXX: please check my super basic trig - this should follow from `last` to `next` up until the
+                    //      intersect at the target Z distance.
+                    fn(last.followTo(next, dist2next * deltaZ / deltaZFullMove).setZ(next.z), offset++);
                 } else {
-                  next = next.clone().setZ(fromZ - deltaZFullMove);
+                    next = next.clone().setZ(fromZ - deltaZFullMove);
                 }
 
                 fromZ = next.z;

--- a/src/geo/polygon.js
+++ b/src/geo/polygon.js
@@ -1162,21 +1162,13 @@ class Polygon {
                 // When "in Ease-Down" (ie. while target Z not yet reached) - follow path while slowly decreasing Z.
                 let deltaZ = fromZ - next.z;
                 dist2next = last.distTo2D(next);
+                next = next.clone().setZ(fromZ - dist2next * slope);
 
-                if (dist2next > maxDist2d) {
-                    // long move: synth intermediate - neccessary?
-                    last = next = last.followTo(next, maxDist2d).setZ(last.z - maxDist2d * slope)
-                    fromZ = next.z;
-                    fn(next, offset++);
-                    continue;
-                } else {
-                    // too short: clone n move z
-                    next = next.clone().setZ(fromZ - maxDist2d * slope);
-                }
                 fromZ = next.z;
             } else if (offset === 0 && next.z < fromZ) {
                 // First point, move to rampZ height above next.
                 let deltaZ = fromZ - next.z;
+
                 fromZ = next.z + Math.min(deltaZ, rampZ)
                 next = next.clone().setZ(fromZ);
             }

--- a/src/geo/polygon.js
+++ b/src/geo/polygon.js
@@ -1169,6 +1169,7 @@ class Polygon {
                     //      intersect at the target Z distance.
                     fn(last.followTo(next, dist2next * deltaZ / deltaZFullMove).setZ(next.z), offset++);
                 } else {
+                    // Ok: execute full move at desired slope.
                     next = next.clone().setZ(fromZ - deltaZFullMove);
                 }
 

--- a/src/geo/polygon.js
+++ b/src/geo/polygon.js
@@ -1162,7 +1162,17 @@ class Polygon {
                 // When "in Ease-Down" (ie. while target Z not yet reached) - follow path while slowly decreasing Z.
                 let deltaZ = fromZ - next.z;
                 dist2next = last.distTo2D(next);
-                next = next.clone().setZ(fromZ - dist2next * slope);
+                let deltaZFullMove = dist2next * slope;
+
+                if (deltaZFullMove > deltaZ) {
+                  // Too long: easing along full path would overshoot depth, synth intermediate point at target Z.
+                  //
+                  // XXX: please check my super basic trig - this should follow from `last` to `next` up until the
+                  //      intersect at the target Z distance.
+                  fn(last.followTo(next, dist2next * deltaZ / deltaZFullMove).setZ(next.z), offset++);
+                } else {
+                  next = next.clone().setZ(fromZ - deltaZFullMove);
+                }
 
                 fromZ = next.z;
             } else if (offset === 0 && next.z < fromZ) {

--- a/src/geo/polygon.js
+++ b/src/geo/polygon.js
@@ -1148,8 +1148,6 @@ class Polygon {
         const degrees = 1;
         // Slope for computations.
         const slope = Math.tan((degrees * Math.PI) / 180);
-        // Maximum segment length, not sure if that's neccessary. Maybe misunderstanding of existing code.
-        const maxDist2d = 0.5;
         // Z height above polygon Z from which to start the ease-down.
         // Machine will travel from "fromPoint" to "nearest point x, y, z' => with z' = point z + rampZ",
         // then start the ease down along path.

--- a/src/geo/polygon.js
+++ b/src/geo/polygon.js
@@ -1125,7 +1125,7 @@ class Polygon {
      * Ease down along the polygonal path.
      *
      * 1. Travel from fromPoint to closest point on polygon, to rampZ above that that point,
-     * 2. ease-down starts, following the polygonal path, decreasing Z at a fixed slop until target Z is hit,
+     * 2. ease-down starts, following the polygonal path, decreasing Z at a fixed slope until target Z is hit,
      * 3. then the rest of the path is completed and repeated at target Z until touchdown point is reached.
      *
      */
@@ -1143,16 +1143,23 @@ class Polygon {
             done;
 
         // XXX: These should be UI configurable options.
-        const degrees = 1;                                  // Rough "slope" of the ease-down path in degrees. It's probably only a slope if projected onto XZ or YZ planes.
-        const slope = Math.tan((degrees * Math.PI) / 180);  // Slope for computations.
-        const maxDist2d = 0.5;                              // Maximum segment length, not sure if that's neccessary. Maybe misunderstanding of existing code.
-        const rampZ = 2.0;                                  // Z height above polygon Z from which to start the ease-down. Machine will travel from "fromPoint" to "nearest point, Z + rampZ", then start the easy down.
+
+        // "Slope" of the ease-down path in degrees, or an approximation thereof.
+        const degrees = 1;
+        // Slope for computations.
+        const slope = Math.tan((degrees * Math.PI) / 180);
+        // Maximum segment length, not sure if that's neccessary. Maybe misunderstanding of existing code.
+        const maxDist2d = 0.5;
+        // Z height above polygon Z from which to start the ease-down.
+        // Machine will travel from "fromPoint" to "nearest point x, y, z' => with z' = point z + rampZ",
+        // then start the ease down along path.
+        const rampZ = 2.0;
 
         while (true) {
             next = points[index % length];
 
             if (last && next.z < fromZ) {
-                // Only "in Ease-Down" (while target Z not yet reached) - follow path while slowly decreasing Z.
+                // When "in Ease-Down" (ie. while target Z not yet reached) - follow path while slowly decreasing Z.
                 let deltaZ = fromZ - next.z;
                 dist2next = last.distTo2D(next);
 
@@ -1179,12 +1186,12 @@ class Polygon {
               break;
             }
             if (touch < 0 && next.z <= targetZ) {
-                // Save touch-down index so as to be able to "complete" the full cut at target Z, i.e. keep following the path loop until the touch down point is reached again.
+                // Save touch-down index so as to be able to "complete" the full cut at target Z,
+                // i.e. keep following the path loop until the touch down point is reached again.
                 touch = ((index - 1) % length);
             }
             index++;
         }
-
 
         return last;
     }


### PR DESCRIPTION
Ease down along the desired polygonal path - slight modification of the original code to support an angle and a "start offset Z" above desired Z (`rampZ` in the code).

Recap of the code/algo:

1. Travel from first (ie. starting) `fromPoint` to closest point on polygon at `rampZ` above that that point,
2. ease-down along one or more points of the polygon, decreasing Z at a fixed slope until target Z is reached,
  a. if a long move with desired slope would overshoot target Z, break it up to just hit target Z,
4. note touchdown point and then follow the rest of the path and repeat segments at target Z until touchdown point is reached again (this ensures that the initial ramp is fully cleared at target Z height where needed).

Caveats:
* There was a mention on Discord of the current EaseDown code supporting a configurable angle that just was not shown in the UI - I did not see that here so either I misunderstood the existing code or modified the wrong piece of code and this change already exists somewhere else.

Example: rampZ = 2, degree = 1.

![p1](https://github.com/user-attachments/assets/eafd3125-4820-4dc8-9f68-621ea1c5b067)