### PR TITLE
Make CNC outline operation respect the ease down option

### DIFF
--- a/src/kiri-mode/cam/ops.js
+++ b/src/kiri-mode/cam/ops.js
@@ -707,11 +707,7 @@ class OpOutline extends CamOp {
             if (depthFirst) {
                 depthData.push(polys);
             } else {
-                printPoint = poly2polyEmit(polys, printPoint, function(poly, index, count) {
-                    poly.forEachPoint(function(point, pidx, points, offset) {
-                        camOut(point.clone(), offset !== 0);
-                    }, poly.isClosed(), index);
-                }, { swapdir: false });
+                printPoint = poly2polyEmit(polys, printPoint, polyEmit, { swapdir: false });
                 newLayer();
             }
         }


### PR DESCRIPTION
Hello and thank you for a great opensource tool!

I noticed that the CNC outline operation didn't respect the ease down option and I needed that in my work flow so I changed the OPOutline class so that now it does.

I don't know if there was reason for the outlines not to use it but decided to open a pr in case that was a bug and you would be interested in adding this to the master.

I tested with couple of my parts that outlines seems to be working with and without the ease down option but didn't do any wider testing.

With a quick look I didn't see any contributing guide so let me know if you are accepting contributions and if there is a process I should follow.