### PR TITLE
Add Drill tool type to CAM

### DIFF
--- a/src/kiri-mode/cam/client.js
+++ b/src/kiri-mode/cam/client.js
@@ -3,6 +3,8 @@
 "use strict";
 
 // dep: kiri-mode.cam.driver
+// dep: kiri.api
+// dep: kiri.alerts
 // use: kiri-mode.cam.animate
 // use: kiri-mode.cam.animate2
 // use: kiri-mode.cam.tools
@@ -10,7 +12,8 @@
 gapp.register("kiri-mode.cam.client", [], (root, exports) => {
 
 const { base, kiri } = root;
-const { driver } = kiri;
+const { driver, api } = kiri;
+const {alerts, conf} = api;
 const { CAM } = driver;
 const DEG2RAD = Math.PI / 180;
 const RAD2DEG = 180 / Math.PI;
@@ -1728,6 +1731,17 @@ function createPopOp(type, map) {
         },
         bind: (ev) => {
             API.util.ui2rec(op.rec, op.inputs);
+
+            const settings  = conf.get();
+            const {tool} = new CAM.Tool(settings,op.rec.tool); //get tool by id
+            const opType = op.rec.type
+            if( opType != "drill" && tool.type == "drill"){
+                alerts.show(`Warning: Drills should not be used for ${opType} operations.`)
+            }
+            if( opType == "drill" && tool.type != "drill"){
+                alerts.show(`Warning: Only drills should be used for drilling operations.`)
+            }
+
             for (let [key, val] of Object.entries(op.rec)) {
                 let saveTo = map[key];
                 if (saveTo && typeof(key) === 'string' && !key.startsWith("~")) {

--- a/src/kiri-mode/cam/tool.js
+++ b/src/kiri-mode/cam/tool.js
@@ -111,7 +111,7 @@ class Tool {
     generateProfile(resolution) {
         // generate tool profile
         let ball = this.isBallMill(),
-            taper = this.isTaperMill() || this.isDrill(),
+            taper = this.hasTaper(),
             tip_diameter = this.tipDiameter(),
             shaft_offset = this.fluteLength(),
             flute_diameter = this.fluteDiameter(),

--- a/src/kiri-mode/cam/tool.js
+++ b/src/kiri-mode/cam/tool.js
@@ -105,7 +105,7 @@ class Tool {
     }
 
     hasTaper() {
-        return this.isTaperMill() || this.isDrill();
+        return this.isTaperMill();
     }
 
     generateProfile(resolution) {

--- a/src/kiri-mode/cam/tool.js
+++ b/src/kiri-mode/cam/tool.js
@@ -67,11 +67,11 @@ class Tool {
     }
 
     traceOffset() {
-        return (this.isTaperMill() ? this.tipDiameter() : this.fluteDiameter()) / 2;
+        return (this.hasTaper() ? this.tipDiameter() : this.fluteDiameter()) / 2;
     }
 
     contourOffset(step) {
-        const diam = Math.min(this.isTaperMill() ? this.tipDiameter() : this.fluteDiameter());
+        const diam = Math.min(this.hasTaper() ? this.tipDiameter() : this.fluteDiameter());
         return diam ? diam * step : step;
     }
 
@@ -100,10 +100,18 @@ class Tool {
         return this.tool.type === "tapermill";
     }
 
+    isDrill(){
+        return this.tool.type === "drill";
+    }
+
+    hasTaper() {
+        return this.isTaperMill() || this.isDrill();
+    }
+
     generateProfile(resolution) {
         // generate tool profile
         let ball = this.isBallMill(),
-            taper = this.isTaperMill(),
+            taper = this.isTaperMill() || this.isDrill(),
             tip_diameter = this.tipDiameter(),
             shaft_offset = this.fluteLength(),
             flute_diameter = this.fluteDiameter(),

--- a/src/kiri-mode/cam/tools.js
+++ b/src/kiri-mode/cam/tools.js
@@ -15,7 +15,8 @@ gapp.register("kiri-mode.cam.tools", (root, exports) => {
         DOC = document,
         selectedTool = null,
         editTools = null,
-        maxTool = 0;
+        maxTool = 0,
+        toolNames = ['endmill','ballmill','tapermill','drill'];
 
     api.show.tools = showTools;
 
@@ -41,6 +42,15 @@ gapp.register("kiri-mode.cam.tools", (root, exports) => {
         });
     }
 
+    /**
+     * Check if a tool is a tapermill or drill (i.e. has a taper angle)
+     * @param {String} tool - a string representing the tool type
+     * @return {boolean} true if the tool has a taper angle, false if not
+     */
+    function hasTaper(tool) {
+        return tool === 'tapermill' || tool === 'drill';
+    }
+
     function selectTool(tool) {
         selectedTool = tool;
         ui.toolName.value = tool.name;
@@ -51,8 +61,8 @@ gapp.register("kiri-mode.cam.tools", (root, exports) => {
         ui.toolShaftLen.value = tool.shaft_len;
         ui.toolTaperTip.value = tool.taper_tip || 0;
         ui.toolMetric.checked = tool.metric;
-        ui.toolType.selectedIndex = ['endmill','ballmill','tapermill'].indexOf(tool.type);
-        if (tool.type === 'tapermill') {
+        ui.toolType.selectedIndex = toolNames.indexOf(tool.type);
+        if (hasTaper(tool)) {
             ui.toolTaperAngle.value = kiri.driver.CAM.calcTaperAngle(
                 (tool.flute_diam - tool.taper_tip) / 2, tool.flute_len
             ).round(1);
@@ -83,7 +93,7 @@ gapp.register("kiri-mode.cam.tools", (root, exports) => {
 
     function renderTool(tool) {
         let type = selectedTool.type;
-        let taper = type === 'tapermill';
+        let taper = hasTaper(type)
         ui.toolTaperAngle.disabled = taper ? undefined : 'true';
         ui.toolTaperTip.disabled = taper ? undefined : 'true';
         $('tool-view').innerHTML = '<svg id="tool-svg" width="100%" height="100%"></svg>';
@@ -123,7 +133,7 @@ gapp.register("kiri-mode.cam.tools", (root, exports) => {
                         stroke
                     } }
                 ];
-            if (type === "tapermill") {
+            if (taper) {
                 let yoff = off.y + shaft_len;
                 // let mid = dim.w / 2;
                 parts.push({path: {stroke_width, stroke, fill:flute_fill, d:[
@@ -183,8 +193,8 @@ gapp.register("kiri-mode.cam.tools", (root, exports) => {
         selectedTool.shaft_len = parseFloat(ui.toolShaftLen.value);
         selectedTool.taper_tip = parseFloat(ui.toolTaperTip.value);
         selectedTool.metric = ui.toolMetric.checked;
-        selectedTool.type = ['endmill','ballmill','tapermill'][ui.toolType.selectedIndex];
-        if (selectedTool.type === 'tapermill') {
+        selectedTool.type = toolNames[ui.toolType.selectedIndex];
+        if (hasTaper(selectedTool.type)) {
             const CAM = kiri.driver.CAM;
             const rad = (selectedTool.flute_diam - selectedTool.taper_tip) / 2;
             if (ev && ev.target === ui.toolTaperAngle) {

--- a/web/kiri/index.html
+++ b/web/kiri/index.html
@@ -557,6 +557,7 @@
                                 <option value="endmill" lk="td_tyem" selected>end</option>
                                 <option value="ballmill" lk="td_tybm">ball</option>
                                 <option value="tapermill" lk="td_tytm">taper</option>
+                                <option value="drill" lk="td_tydr">drill</option>
                             </select>
                         </div>
                         <div class="f-row var-row" title="tool number to use&#010;in gcode commands"><label lk="td_tonm">tool #</label><input id="tool-num" size="7"></input></div>

--- a/web/kiri/lang/en.js
+++ b/web/kiri/lang/en.js
@@ -92,6 +92,7 @@ self.kiri.lang['en-us'] = {
     td_tyem:        "end",          // end mill
     td_tybm:        "ball",         // ball mill
     td_tytm:        "taper",        // taper mill
+    td_tydr:        "drill",        // drill
     td_tonm:        "tool #",
     td_shft:        "shaft",        // endmill shaft specs
     td_flut:        "flute",        // endmill flute specs


### PR DESCRIPTION
Adds drills as a tool type, separate from the standard tapered mill. Warns user if using a tool for an inappropriate operation. 

This PR does not block the user from preforming the operation, as this could be a breaking change for some users.

resolves #246