### PR TITLE
Cam-mesh-update

### DIFF
--- a/src/kiri/widget.js
+++ b/src/kiri/widget.js
@@ -60,6 +60,7 @@ class Widget {
         this.slices = null;
         this.settings = null; // used??
         this.modified = true;
+        this.boundingBoxNeedsUpdate = true
         this.track = {
             // box size for packer
             box: {
@@ -229,6 +230,7 @@ class Widget {
 
     setModified() {
         this.modified = true;
+        this.boundingBoxNeedsUpdate
         if (this.mesh && this.mesh.geometry) {
             // this fixes ray intersections after the mesh is modified
             this.mesh.geometry.boundingSphere = null;
@@ -695,9 +697,9 @@ class Widget {
     }
 
     getBoundingBox(refresh) {
-        if (!this.bounds || refresh || this.modified) {
+        if (!this.bounds || refresh || this.boundingBoxNeedsUpdate) {
             this.bounds = new THREE.Box3().setFromArray(this.getGeoVertices());
-            this.modified = false;
+            this.boundingBoxNeedsUpdate = false;
         }
         return this.bounds;
     }

--- a/src/kiri/widget.js
+++ b/src/kiri/widget.js
@@ -230,7 +230,7 @@ class Widget {
 
     setModified() {
         this.modified = true;
-        this.boundingBoxNeedsUpdate
+        this.boundingBoxNeedsUpdate = true;
         if (this.mesh && this.mesh.geometry) {
             // this fixes ray intersections after the mesh is modified
             this.mesh.geometry.boundingSphere = null;


### PR DESCRIPTION
Fixes widget desync with worker memory.

Before fix, If you select traces, rotate part, and then select traces again:

![image](https://github.com/user-attachments/assets/ea660a24-3eea-4c0e-bf3f-222fb5ae3e67)

After fix:

![image](https://github.com/user-attachments/assets/43d276a6-aad3-4f2d-8dd5-c0b3abea2bb0)