### PR TITLE
Add rudimentary widget split functionality

### DIFF
--- a/src/kiri/init.js
+++ b/src/kiri/init.js
@@ -2071,7 +2071,7 @@ gapp.register("kiri.init", (root, exports) => {
         $('mesh-export-stl').onclick = () => { objectsExport('stl') };
         $('mesh-export-obj').onclick = () => { objectsExport('obj') };
         $('mesh-merge').onclick = selection.merge;
-        $('mesh-split').onclick = selection.split;
+        $('mesh-isolate').onclick = selection.isolate;
         $('context-duplicate').onclick = duplicateSelection;
         $('context-mirror').onclick = mirrorSelection;
         $('context-layflat').onclick = () => { api.event.emit("tool.mesh.lay-flat") };

--- a/src/kiri/init.js
+++ b/src/kiri/init.js
@@ -2071,6 +2071,7 @@ gapp.register("kiri.init", (root, exports) => {
         $('mesh-export-stl').onclick = () => { objectsExport('stl') };
         $('mesh-export-obj').onclick = () => { objectsExport('obj') };
         $('mesh-merge').onclick = selection.merge;
+        $('mesh-split').onclick = selection.split;
         $('context-duplicate').onclick = duplicateSelection;
         $('context-mirror').onclick = mirrorSelection;
         $('context-layflat').onclick = () => { api.event.emit("tool.mesh.lay-flat") };

--- a/src/kiri/selection.js
+++ b/src/kiri/selection.js
@@ -210,8 +210,23 @@ function merge() {
         }
     });
     let w = api.platform.load_verts([], obj, "merged");
+    w.mergedFrom = sel.map(widget => widget.mesh.geometry.attributes.position.array);
     api.platform.delete(sel);
     api.platform.select(w);
+}
+
+function split(){
+    let sel = widgets();
+    if (sel.length === 0) {
+        sel = api.widgets.all();
+    }
+    sel.forEach(widget => {
+        if(widget.mergedFrom && Array.isArray(widget.mergedFrom)){
+            widget.mergedFrom.forEach((verts,i) => {
+                api.platform.load_verts([],verts,`split ${i}`);
+            });        }
+        api.platform.delete(widget);
+    })
 }
 
 function exportWidgets(format = "stl") {
@@ -299,6 +314,7 @@ function setDisabled(bool) {
 const selection = Object.assign(api.selection, {
     move,
     merge,
+    split,
     scale,
     rotate,
     mirror,

--- a/src/kiri/selection.js
+++ b/src/kiri/selection.js
@@ -220,13 +220,19 @@ function split(){
     if (sel.length === 0) {
         sel = api.widgets.all();
     }
+    let anySplits = false
     sel.forEach(widget => {
         if(widget.mergedFrom && Array.isArray(widget.mergedFrom)){
             widget.mergedFrom.forEach((verts,i) => {
                 api.platform.load_verts([],verts,`split ${i}`);
-            });        }
-        api.platform.delete(widget);
+                anySplits = true
+            });        
+            api.platform.delete(widget);
+        }
     })
+    if(!anySplits){
+        kiri.api.alerts.show("Nothing to split in selection",3000)
+    }
 }
 
 function exportWidgets(format = "stl") {

--- a/src/kiri/selection.js
+++ b/src/kiri/selection.js
@@ -6,11 +6,14 @@
 // dep: kiri.api
 // dep: kiri.consts
 // dep: kiri.utils
+// dep: mesh.tool
 gapp.register("kiri.selection", (root, exports) => {
 
-const { kiri, moto, noop } = self;
+
+const { kiri, moto, noop, mesh } = self;
 const { api, consts, utils } = kiri;
 const { space } = moto;
+
 
 const selectedMeshes = [];
 
@@ -210,23 +213,36 @@ function merge() {
         }
     });
     let w = api.platform.load_verts([], obj, "merged");
-    w.mergedFrom = sel.map(widget => widget.mesh.geometry.attributes.position.array);
     api.platform.delete(sel);
     api.platform.select(w);
 }
 
-function split(){
+function isolate(){
+    
+    let mTool = new self.mesh.tool();
+
+    console.log(mTool)
     let sel = widgets();
     if (sel.length === 0) {
         sel = api.widgets.all();
     }
     let anySplits = false
     sel.forEach(widget => {
-        if(widget.mergedFrom && Array.isArray(widget.mergedFrom)){
-            widget.mergedFrom.forEach((verts,i) => {
-                api.platform.load_verts([],verts,`split ${i}`);
+        let verts = widget.mesh.geometry.attributes.position.array
+        if( verts ){
+            
+
+            mTool.index(verts);
+
+            let isolated = mTool.isolateBodies();
+
+            // console.log(isolated)
+            for(let [v,i] of isolated.entries()){
+                api.platform.load_verts([],v,`split ${i}`);
                 anySplits = true
-            });        
+            }
+
+
             api.platform.delete(widget);
         }
     })
@@ -320,7 +336,7 @@ function setDisabled(bool) {
 const selection = Object.assign(api.selection, {
     move,
     merge,
-    split,
+    isolate,
     scale,
     rotate,
     mirror,

--- a/web/kiri/index.html
+++ b/web/kiri/index.html
@@ -284,6 +284,7 @@
                 <div id="ft-mesh" class="grow f-col pop">
                     <div id="ft-mesh-btn">
                         <div><button id="mesh-merge" lk="rc_merg">Merge</button></div>
+                        <div><button id="mesh-split" lk="rc_splt">Split</button></div>
                         <div><button id="mesh-export-obj" lk="rc_xobj">export OBJ</button></div>
                         <div><button id="mesh-export-stl" lk="rc_xstl">export STL</button></div>
                     </div>

--- a/web/kiri/index.html
+++ b/web/kiri/index.html
@@ -284,7 +284,7 @@
                 <div id="ft-mesh" class="grow f-col pop">
                     <div id="ft-mesh-btn">
                         <div><button id="mesh-merge" lk="rc_merg">Merge</button></div>
-                        <div><button id="mesh-split" lk="rc_splt">Split</button></div>
+                        <div><button id="mesh-isolate" lk="rc_splt">Split</button></div>
                         <div><button id="mesh-export-obj" lk="rc_xobj">export OBJ</button></div>
                         <div><button id="mesh-export-stl" lk="rc_xstl">export STL</button></div>
                     </div>

--- a/web/kiri/lang/en.js
+++ b/web/kiri/lang/en.js
@@ -78,6 +78,7 @@ self.kiri.lang['en-us'] = {
     rc_xstl:        "export STL",
     sb_info:        ["print speed","in mm/s"],
     rc_merg:        "merge object meshes",
+    rc_splt:        "split object meshes",
 
     // DEVICE MENU and related dialogs
     dm_sldt:        "select a device type",

--- a/web/kiri/lang/en.js
+++ b/web/kiri/lang/en.js
@@ -78,7 +78,7 @@ self.kiri.lang['en-us'] = {
     rc_xstl:        "export STL",
     sb_info:        ["print speed","in mm/s"],
     rc_merg:        "merge object meshes",
-    rc_splt:        "split object meshes",
+    rc_splt:        "isolate object meshes",
 
     // DEVICE MENU and related dialogs
     dm_sldt:        "select a device type",


### PR DESCRIPTION
Adds a button to split widgets after they have been merged. Only works for one layer of merging. Alerts user if nothing has been split.
![image](https://github.com/user-attachments/assets/1067864c-9d4a-49a2-b493-725635d21afe)
