### PR TITLE
Outline order

### DIFF
--- a/src/kiri-mode/cam/ops.js
+++ b/src/kiri-mode/cam/ops.js
@@ -707,8 +707,8 @@ class OpOutline extends CamOp {
             let polys = [], t = [], c = [];
             let lines =POLY.flatten(slice.camLines)
             // console.log(lines);
-            lines.forEach(l =>{ if(l.order == undefined) l.order = 0; });
-            lines.forEach(function (poly) {
+            lines.forEach((poly)=> {
+                poly.order = poly.order ?? 0;
                 let child = poly.parent;
                 if (depthFirst) { poly = poly.clone(); poly.parent = child ? 1 : 0 }
                 if (child) c.push(poly); else t.push(poly);

--- a/src/kiri-mode/cam/ops.js
+++ b/src/kiri-mode/cam/ops.js
@@ -628,12 +628,18 @@ class OpOutline extends CamOp {
             } else {
                 if (op.wide) {
                     let stepover = toolDiam * op.step;
-                    for (let c = (op.steps || 1); c > 0; c--)
-                    offset.slice().forEach(op => {
-                        // clone removes inners but the real solution is
-                        // to limit expanded shells to through holes
-                        POLY.expand([op.clone(true)], stepover, slice.z, offset, 1);
-                    });
+                    for (let c = (op.steps || 1); c > 0; c--){
+                        offset.slice().forEach(op => {
+                            // clone removes inners but the real solution is
+                            // to limit expanded shells to through holes
+                            let wideCut = POLY.expand([op.clone(true)], stepover, slice.z, [], 1);
+                            wideCut.forEach(cut =>{ //set order of cuts when wide
+                                cut.order = c 
+                                cut.inner.forEach(inn =>{ inn.order = c })
+                            });
+                            offset.push(...wideCut)
+                        });
+                    }
                 }
             }
 
@@ -697,7 +703,9 @@ class OpOutline extends CamOp {
 
         for (let slice of sliceOut) {
             let polys = [], t = [], c = [];
-            POLY.flatten(slice.camLines).forEach(function (poly) {
+            let lines =POLY.flatten(slice.camLines)
+            lines.forEach(l =>{ if(l.order == undefined) l.order = 0; });
+            lines.forEach(function (poly) {
                 let child = poly.parent;
                 if (depthFirst) { poly = poly.clone(); poly.parent = child ? 1 : 0 }
                 if (child) c.push(poly); else t.push(poly);
@@ -713,11 +721,21 @@ class OpOutline extends CamOp {
             if (depthFirst) {
                 depthData.push(polys);
             } else {
-                printPoint = poly2polyEmit(polys, printPoint, function(poly, index, count) {
-                    poly.forEachPoint(function(point, pidx, points, offset) {
-                        camOut(point.clone(), offset !== 0);
-                    }, poly.isClosed(), index);
-                }, { swapdir: false });
+                let orderSplit = {}
+                polys.forEach(poly => {
+                    if(poly.order in orderSplit) orderSplit[poly.order].push(poly);
+                    else orderSplit[poly.order] = [poly];
+                })
+                Object.entries(orderSplit) //split the polys by order
+                .sort((a,b) => -(a[0] - b[0] )) //sort by order (highest first)
+                .forEach(([order, orderPolys]) => { // emit based on closest for each order
+                    // console.log({order, orderPolys});
+                    printPoint = poly2polyEmit(orderPolys, printPoint, function(poly, index, count) {
+                        poly.forEachPoint(function(point, pidx, points, offset) {
+                            camOut(point.clone(), offset !== 0);
+                        }, poly.isClosed(), index);
+                    }, { swapdir: false });
+                })
                 newLayer();
             }
         }

--- a/src/kiri-mode/cam/ops.js
+++ b/src/kiri-mode/cam/ops.js
@@ -706,7 +706,7 @@ class OpOutline extends CamOp {
         for (let slice of sliceOut) {
             let polys = [], t = [], c = [];
             let lines =POLY.flatten(slice.camLines)
-            console.log(lines);
+            // console.log(lines);
             lines.forEach(l =>{ if(l.order == undefined) l.order = 0; });
             lines.forEach(function (poly) {
                 let child = poly.parent;
@@ -732,7 +732,7 @@ class OpOutline extends CamOp {
                 Object.entries(orderSplit) //split the polys by order
                 .sort((a,b) => -(a[0] - b[0] )) //sort by order (highest first)
                 .forEach(([order, orderPolys]) => { // emit based on closest for each order
-                    console.log({order, orderPolys});
+                    // console.log({order, orderPolys});
                     printPoint = poly2polyEmit(orderPolys, printPoint, function(poly, index, count) {
                         poly.forEachPoint(function(point, pidx, points, offset) {
                             camOut(point.clone(), offset !== 0);


### PR DESCRIPTION
Orders polygons based on their proximity to the main outline. Implements order separation in the `prepare` function, so It can be used for other things in the future.

fixes #342

Before:
![image](https://github.com/user-attachments/assets/0ad18c72-8d3c-459c-bbf3-f1a899aa3b06)

After:
![image](https://github.com/user-attachments/assets/0ae63e8d-d60f-46cb-af7c-161621338491)

