### PR TITLE
Specify no publishing for build test GH action

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Build Electron app
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-        run: npm run build
+        run: npm run build-nopublish
         
   build-windows:
     runs-on: "windows-latest"
@@ -46,7 +46,7 @@ jobs:
       - name: Build Electron app
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-        run: npm run build
+        run: npm run build-nopublish
 
 
 

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
         "start-dbg": "npm run prebuild && electron . --debugg",
         "start-ddb": "npm run prebuild && electron . --devel --debugg",
         "build": "npm run prebuild && electron-builder",
+        "build-nopublish": "npm run prebuild && electron-builder --publish never",
         "build-debug": "npm run prebuild && DEBUG=electron-builder electron-builder",
         "build-linux": "npm run build -- --linux --x64",
         "build-linux-arm": "npm run build -- --linux --arm64",


### PR DESCRIPTION
The electron build test GH action is trying to auto-publish. This will explicitly tell it to not do that.