### PR TITLE
Documentation Upkeep

### DIFF
--- a/docs/kiri-moto/apis.md
+++ b/docs/kiri-moto/apis.md
@@ -8,11 +8,7 @@ description: Various ways to access Kiri:Moto's internals (2.6 and newer version
 
 The latest slicing engine code is served live at `https://grid.space/code/engine.js`
 
-This can be embedded in your page then accessed with the API calls defined on the [Engine APIs](kiri-moto/engine-apis) page
-
-An example page is [here](https://grid.space/kiri/engine.html).
-
-
+This can be embedded in your page then accessed with the API calls defined on the [Engine APIs](engine-apis) page.
 
 ## Command Line API
 

--- a/docs/kiri-moto/apis.md
+++ b/docs/kiri-moto/apis.md
@@ -8,25 +8,11 @@ description: Various ways to access Kiri:Moto's internals (2.6 and newer version
 
 The latest slicing engine code is served live at `https://grid.space/code/engine.js`
 
-This can be embedded in your page then accessed with the following API calls. An example page is [here](https://grid.space/kiri/engine.html).
+This can be embedded in your page then accessed with the API calls defined on the [Engine APIs](kiri-moto/engine-apis) page
 
-| function               | description                                                                                             |
-| ---------------------- | ------------------------------------------------------------------------------------------------------- |
-| load(_url_)            | load an [STL](https://en.wikipedia.org/wiki/STL\_\(file\_format\)) referred to by _url_                 |
-| clear()                | remove all objects from workspace                                                                       |
-| parse(_data_)          | parse the text or binary contents of an [STL](https://en.wikipedia.org/wiki/STL\_\(file\_format\)) file |
-| setMode(_mode_)        | where _mode_ comes from:`[ "CAM", "FDM", "LASER", "SLA" ]`                                              |
-| setListener(_fn_)      | a function to receive engine progress messages                                                          |
-| setDevice(_options_)   | change default Device options                                                                           |
-| setProcess(options)    | change default Process options                                                                          |
-| setController(options) | change default Core options                                                                             |
-| moveTo(_x, y, z_)      | absolute move the origin of the loaded object                                                           |
-| move(_x, y, z_)        | relative move the origin of the loaded object                                                           |
-| scale(_x, y, z_)       | scale axes of the loaded object                                                                         |
-| rotate(_x, y, z_)      | relative rotate axes of loaded object (in radians)                                                      |
-| slice()                | async slice of loaded object                                                                            |
-| prepare()              | async path routing of slice data                                                                        |
-| export()               | async gcode generation from routed paths                                                                |
+An example page is [here](https://grid.space/kiri/engine.html).
+
+
 
 ## Command Line API
 

--- a/docs/kiri-moto/engine-apis.md
+++ b/docs/kiri-moto/engine-apis.md
@@ -1,0 +1,54 @@
+---
+description: options for accessing KM's engine APIs
+label: Engine APIs
+---
+
+# Engine APIs
+The `Engine` class serves as an abstraction layer for interacting with the `kiri` 3D slicing engine. It handles loading and parsing STL files, manipulating widgets (3D models), configuring slicing parameters, and executing the toolpath generation pipeline: slice, prepare, and export.
+
+This API is designed with method chaining in mind, and provides hooks for custom event listeners.
+
+you can view some example of how to use the engine [here](https://grid.space/kiri/engine.html).
+
+
+---
+
+## Methods
+
+| Method | Description | Returns |
+|--------|-------------|---------|
+| `load(url)` | Loads an [STL](https://en.wikipedia.org/wiki/STL\_\(file\_format\)) file from a given URL and centers the model. | `Promise<Engine>` |
+| `clear()` | Clears all objects from workspace. | `void` |
+| `parse(data)` | Parses raw [STL](https://en.wikipedia.org/wiki/STL\_\(file\_format\)) data and loads it as a centered widget. | `Promise<Engine>` |
+| `setListener(listener)` | Sets an event listener function to receive engine progress updates  | `Engine` |
+| `setRender(bool)` | Enables or disables rendering. | `Engine` |
+| `setMode(mode)` | Sets the slicing mode where mode is "CAM"|"FDM"|"LASER"|"SLA" . | `Engine` |
+| `setDevice(device)` | Merges a custom device profile into the current settings. | `Engine` |
+| `setProcess(process)` | Merges custom slicing process parameters. | `Engine` |
+| `setController(controller)` | Sets the slicing controller settings and starts/stops the worker pool accordingly. | `Engine` |
+| `setTools(tools)` | Sets the tool definitions (e.g. cutters, extruders). | `Engine` |
+| `setStock(stock)` | Sets the stock material dimensions. | `Engine` |
+| `setOrigin(x, y, z)` | Defines the origin point for the part. | `Engine` |
+| `moveTo(x, y, z)` | Moves the widget to the specified absolute coordinates. | `Engine` |
+| `move(x, y, z)` | Moves the widget by the specified delta values. | `Engine` |
+| `scale(x, y, z)` | Scales the widget along each axis. | `Engine` |
+| `rotate(x, y, z)` | Rotates the widget in degrees along each axis. | `Engine` |
+| `slice()` | Starts the slicing process and returns once complete. | `Promise<Engine>` |
+| `prepare()` | Prepares the sliced toolpaths for export (e.g. G-code generation). | `Promise<Engine>` |
+| `export()` | Exports the toolpaths as a string (e.g. G-code). | `Promise<string>` |
+
+---
+
+## Events via Listener
+
+If a listener is set via `setListener(fn)`, it will be called with events such as:
+
+- `{ loaded, vertices }` — when an STL file is loaded
+- `{ parsed, vertices }` — when raw data is parsed
+- `{ slice: msg }` — when slicing is complete
+- `{ prepare: { update } }` — during toolpath preparation
+- `{ prepare: { done: true } }` — when preparation is complete
+- `{ export: { segment } }` — during G-code segment export
+- `{ export: { done } }` — when export is finished
+
+These allow for building progress indicators or responding to processing stages.

--- a/docs/kiri-moto/gcode-macros.md
+++ b/docs/kiri-moto/gcode-macros.md
@@ -112,3 +112,13 @@ _`;; SCALE { "X":100, "Y":100, "Z":100 }`_
  Allows for over-riding the default axis names. Useful for swapping axes and changing output for specific firmware targets. The format of the map is a JSON object._
 
 `;; AXISMAP {"X":"Y", "Y":"Z", "E":"E1"}`
+
+
+## Laser Mode Only
+
+### Laser Macros
+
+- \{power\} = laser power
+- \{color\} = assigned color
+- \{thick\} = assigned thickness
+- \{z\} = current z position

--- a/docs/kiri-moto/gcode-macros.md
+++ b/docs/kiri-moto/gcode-macros.md
@@ -6,14 +6,14 @@ description: Variable Substitutions and Expressions in GCode Macros
 
 ## All Modes
 
-### "pre" and "post" (header/footer)
+### "Header"/"Footer" Only Macros
 
 - \{top\} = offset in mm of bed top Y axis
 - \{left\} = offset in mm of bed left X axis
 - \{right\} = offset in mm of bed right X axis
 - \{bottom\} = offset in mm of bed bottom Y axis
 
-### Only "post" (footer)
+### "Footer" Only Macros
 
 - \{time\} = job run time (printing/milling) in seconds (fractional)
 - \{print-time\} = alias for \{time\} ... deprecated after 2.8
@@ -22,13 +22,7 @@ description: Variable Substitutions and Expressions in GCode Macros
 
 ## FDM (3D Printing) Mode Only
 
-
-### "feature" macro only (as of 3.4)
-
-- \{feature\} = feature region of the print (brims, infill, etc)
-- \{minx|miny|maxx|maxy\} = position in mm of extents of the print area
-
-### "pre", "post", and other macros
+### FDM Macros
 
 - \{temp\} = hot end temperature
 - \{bed_temp\} = bed temperature
@@ -49,8 +43,11 @@ description: Variable Substitutions and Expressions in GCode Macros
 - \{z\} = current z position
 - \{e\} = amount of filament extruded
 
-### _Logical Code Flow (IF / ELIF / ELSE / END)_
+### "Feature" only Macros (v3.4+)
+- \{feature\} = feature region of the print (brims, infill, etc)
+- \{minx|miny|maxx|maxy\} = position in mm of extents of the print area
 
+### Logical Code Flow (IF / ELIF / ELSE / END)
 ```
 ;; IF { layer >= 10 && layer <= 20 }
 ;; ..... inside 10-20 layer={layer}
@@ -61,29 +58,14 @@ description: Variable Substitutions and Expressions in GCode Macros
 ;; END
 ```
 
-### _PREAMBLE control (v3.4+) 
+### PREAMBLE control (v3.4+) 
+Allows for intro comment and config list to be re-positioned after the header or disabled. This was introduced to allow GCode output to work with Ultimaker.
 
-Allows for intro comment and config list to be re-positioned after the header or disabled. This was introduced to allow GCode output to work with Ultimaker._
+`;; PREAMBLE OFF`
 
-_`;; PREAMBLE OFF`_
-
-_`;; PREAMBLE END`_
+`;; PREAMBLE END`
 
 ## CAM Mode Only
-
-### CAM Header Directives
-
-Comments Rewrite (v3.8+) converts `;` comments into `()` parenthesis format
-
-_`;; COMMENT_REWRITE_PARENS`_
-
-Minimize the size of GCode output (v3.8+)
-
-_`;; COMPACT-OUTPUT`_
-
-Set decimal precision (n = integer) (v3.8+)
-
-_`;; DECIMALS = n`_
 
 ### CAM Macros
 
@@ -99,7 +81,21 @@ _`;; DECIMALS = n`_
 - \{pos_y\} = last output Y position
 - \{pos_z\} = last output Z position
 
-## Axis Scaling (v3.7+)
+### CAM Header Directives
+
+Comments Rewrite (v3.8+) converts `;` comments into `()` parenthesis format
+
+`;; COMMENT_REWRITE_PARENS`
+
+Minimize the size of GCode output (v3.8+)
+
+`;; COMPACT-OUTPUT`
+
+Set decimal precision (n = integer) (v3.8+)
+
+`;; DECIMALS = n`
+
+### Axis Scaling (v3.7+)
 Allows for a factor to be applied to X,Y,Z coordinates. Useful for some machines like the Roland MDX-40A that uses an unusual coordinate space. Default axis scale is `1`
 
 _`;; SCALE { "X":100, "Y":100, "Z":100 }`_

--- a/docs/kiri-moto/gcode-macros.md
+++ b/docs/kiri-moto/gcode-macros.md
@@ -4,29 +4,31 @@ description: Variable Substitutions and Expressions in GCode Macros
 
 # GCode Macros
 
-**FDM (3D Printing) variable substitutions**
+## All Modes
 
-_All Modes "pre" and "post" (header/footer)_
+### "pre" and "post" (header/footer)
 
 - \{top\} = offset in mm of bed top Y axis
 - \{left\} = offset in mm of bed left X axis
 - \{right\} = offset in mm of bed right X axis
 - \{bottom\} = offset in mm of bed bottom Y axis
 
-_All Modes "post" (footer)_
+### Only "post" (footer)
 
 - \{time\} = job run time (printing/milling) in seconds (fractional)
 - \{print-time\} = alias for \{time\} ... deprecated after 2.8
 - \{print_time\} = alias for \{time\} ... 2.9 and beyond
 
-_3D printing / FDM mode only_
 
-"feature" macro only (as of 3.4)
+## FDM (3D Printing) Mode Only
+
+
+### "feature" macro only (as of 3.4)
 
 - \{feature\} = feature region of the print (brims, infill, etc)
 - \{minx|miny|maxx|maxy\} = position in mm of extents of the print area
 
-"pre", "post", and other macros
+### "pre", "post", and other macros
 
 - \{temp\} = hot end temperature
 - \{bed_temp\} = bed temperature
@@ -47,7 +49,7 @@ _3D printing / FDM mode only_
 - \{z\} = current z position
 - \{e\} = amount of filament extruded
 
-_Logical Code Flow (IF / ELIF / ELSE / END)_
+### _Logical Code Flow (IF / ELIF / ELSE / END)_
 
 ```
 ;; IF { layer >= 10 && layer <= 20 }
@@ -59,17 +61,17 @@ _Logical Code Flow (IF / ELIF / ELSE / END)_
 ;; END
 ```
 
-_PREAMBLE control (v3.4+) allows for intro comment and config list to be re-positioned after the header or disabled. This was introduced to allow GCode output to work with Ultimaker._
+### _PREAMBLE control (v3.4+) 
+
+Allows for intro comment and config list to be re-positioned after the header or disabled. This was introduced to allow GCode output to work with Ultimaker._
 
 _`;; PREAMBLE OFF`_
 
 _`;; PREAMBLE END`_
 
-_Axis Remapping (v3.5+) allows for over-riding the default axis names. Useful for swapping axes and changing output for specific firmware targets. The format of the map is a JSON object._
+## CAM Mode Only
 
-_`;; AXISMAP {"X":"Y", "Y":"Z", "E":"E1"}`_
-
-#### CAM Header Directives
+### CAM Header Directives
 
 Comments Rewrite (v3.8+) converts `;` comments into `()` parenthesis format
 
@@ -83,7 +85,7 @@ Set decimal precision (n = integer) (v3.8+)
 
 _`;; DECIMALS = n`_
 
-**CAM variable substitutions**
+### CAM Macros
 
 - \{tool\} = CAM tool #
 - \{tool_name\} = CAM tool name
@@ -97,12 +99,20 @@ _`;; DECIMALS = n`_
 - \{pos_y\} = last output Y position
 - \{pos_z\} = last output Z position
 
-_Axis Scaling (v3.7+) allows for a factor to be applied to X,Y,Z coordinates. Useful for some machines like the Roland MDX-40A that uses an unusual coordinate space. Default axis scale is `1`_
+## Axis Scaling (v3.7+)
+Allows for a factor to be applied to X,Y,Z coordinates. Useful for some machines like the Roland MDX-40A that uses an unusual coordinate space. Default axis scale is `1`
 
 _`;; SCALE { "X":100, "Y":100, "Z":100 }`_
 
-**CAM & FDM : simple algebraic expression support**
+ ## CAM & FDM Modes 
+ 
+ ### Simple Algebraic Expression Support
 
 - Text inside `{}` is evaluated algebraically with access to JS classes and methods
 - `{Math.min(layer/layers, 0.5) + 1}`
 - `{token+n} {token-n}`
+
+### Axis Remapping (v3.5+)
+ Allows for over-riding the default axis names. Useful for swapping axes and changing output for specific firmware targets. The format of the map is a JSON object._
+
+`;; AXISMAP {"X":"Y", "Y":"Z", "E":"E1"}`

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -24,6 +24,7 @@ const sidebars = {
             "kiri-moto/shared-profiles",
             "kiri-moto/gcode-macros",
             "kiri-moto/apis",
+            "kiri-moto/engine-apis",
             "kiri-moto/localization",
             "kiri-moto/octoprint",
             "kiri-moto/faq",

--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,7 @@ Kiri:Moto and Mesh:Tool are completely open source and free for use without rest
 # Documentation
 [Documentation](https://docs.grid.space/) -- Could really use help with this  
 
-Docs are build with [Docusaurus](https://docusaurus.io/) and served using [github pages](https://pages.github.com/).
+Docs are build with [Docusaurus](https://docusaurus.io/) and served using [GitHub Pages](https://pages.github.com/).
 
 You can build and view the docs locally with:
 ```

--- a/readme.md
+++ b/readme.md
@@ -10,14 +10,12 @@
 ![GitHub](https://img.shields.io/github/license/GridSpace/grid-apps)
 
 
-# Community & Documentation
+# Community
 
 [Discord](https://discord.com/invite/suyCCgr) -- Live Chat  
 [Forums](https://forum.grid.space/) -- Long Form and Archival Discussion  
 [BlueSky](https://bsky.app/profile/grid.space) -- Like the Good 'Ol Days  
 [YouTube](https://www.youtube.com/c/gridspace) -- Content when I have time  
-[Documentation](https://docs.grid.space/) -- Could really use help with this  
-
 
 # Free and Open Source
 
@@ -26,6 +24,18 @@ Kiri:Moto and Mesh:Tool are completely open source and free for use without rest
 [![GitHub Sponsors](https://img.shields.io/github/sponsors/GridSpace)](https://github.com/sponsors/GridSpace)
 [![Donate](https://img.shields.io/badge/Donate-PayPal-green.svg)](https://paypal.me/gridspace3d?locale.x=en_US)
 
+# Documentation
+[Documentation](https://docs.grid.space/) -- Could really use help with this  
+
+Docs are build with [Docusaurus](https://docusaurus.io/) and served using [github pages](https://pages.github.com/).
+
+You can build and view the docs locally with:
+```
+git clone git@github.com:GridSpace/grid-apps.git
+cd grid-apps
+npm run setup
+npm run docs-dev
+```
 
 # HTML5 Web Apps (Installable)
 


### PR DESCRIPTION
Moved engine APIs to it's own page, preparing for more detailed documentation, and refreshed the gcode macros page, making it more hierarchical, and adding laser macros.