### PR TITLE
make bounding recs 0-based

### DIFF
--- a/src/kiri-mode/cam/ops.js
+++ b/src/kiri-mode/cam/ops.js
@@ -657,7 +657,7 @@ class OpOutline extends CamOp {
             }
 
             if (process.camStockClipTo && stock.x && stock.y && stock.center) {
-                let rect = newPolygon().centerRectangle(stock.center, stock.x, stock.y);
+                let rect = newPolygon().centerRectangle({x:0,y:0}, stock.x, stock.y);
                 offset = cutPolys([rect], offset, slice.z, true);
             }
 
@@ -1000,7 +1000,7 @@ class OpTrace extends CamOp {
         let cutdir = ov_conv;
         let polys = [];
         let stockRect = stock.center && stock.x && stock.y ?
-            newPolygon().centerRectangle(stock.center, stock.x, stock.y) : undefined;
+            newPolygon().centerRectangle({x:0,y:0}, stock.x, stock.y) : undefined;
         updateToolDiams(toolDiam);
 
         if (tabs) {


### PR DESCRIPTION
This fixes the bug, but the whole clip-to button is pretty redundant, because the system won't let you use stock smaller than your mesh in the first place. Why does it exist?

resolves #375 