### PR TITLE
fix drill bug

### DIFF
--- a/src/kiri-mode/cam/slice.js
+++ b/src/kiri-mode/cam/slice.js
@@ -500,6 +500,7 @@ CAM.holes = async function(settings, widget, diam) {
                 continue;
             }
             for (let poly of inner) {
+                if ( poly.points.length < 7 ) continue;
                 let center = poly.calcCircleCenter();
                 center.area = poly.area();
                 center.overlapping = [center]


### PR DESCRIPTION
Polys of 3 points were causing errors. This prevents polys under 7 points from being considered for holes.