### PR TITLE
Cut direction bugfix

### DIFF
--- a/src/kiri-mode/cam/ops.js
+++ b/src/kiri-mode/cam/ops.js
@@ -700,10 +700,6 @@ class OpOutline extends CamOp {
         setTool(op.tool, op.rate, op.plunge);
         setSpindle(op.spindle);
 
-        if (!process.camOutlinePocket) {
-            cutdir = !cutdir;
-        }
-
         // printpoint becomes NaN in engine mode. not sure why but this fixes it
         if(Object.values(printPoint).some(v=>Number.isNaN(v))){ 
             printPoint = newPoint(0,0,0);

--- a/src/kiri-mode/cam/prepare.js
+++ b/src/kiri-mode/cam/prepare.js
@@ -491,6 +491,7 @@ function prepEach(widget, settings, print, firstPoint, update) {
             if (depthFirst) {
                 depthData.push(polys);
             } else {
+                // if not depth first, output the polys in slice order
                 printPoint = poly2polyEmit(polys, printPoint, function(poly, index, count) {
                     poly.forEachPoint(function(point, pidx, points, offset) {
                         // scale speed of first cutting poly since it engages the full bit
@@ -508,10 +509,12 @@ function prepEach(widget, settings, print, firstPoint, update) {
         }
 
         if (depthFirst) {
+            // get inside vals (the positive ones)
             let ins = depthData.map(a => a.filter(p => !isNeg(p.depth)));
             let itops = ins.map(level => {
                 return POLY.nest(level.filter(poly => poly.depth === 0).clone());
             });
+            // get outside vals (the negative ones)
             let outs = depthData.map(a => a.filter(p => isNeg(p.depth)));
             let otops = outs.map(level => {
                 return POLY.nest(level.filter(poly => poly.depth === 0).clone());

--- a/src/kiri/conf.js
+++ b/src/kiri/conf.js
@@ -215,7 +215,6 @@ const renamed = {
     drillDwell: "camDrillDwell",
     drillLift: "camDrillLift",
     drillingOn: "camDrillingOn",
-    camPocketOnlyFinish: "camOutlinePocket",
     camWideCutout: "camOutlineWide",
     outputClockwise: "camConventional"
 };


### PR DESCRIPTION
Makes outline go in the correct direction by removing legacy code. 

I'm working on adding a pocket direction option that will solve both this and #275 