### PR TITLE
Create body isolation function

### DIFF
--- a/src/kiri/core/init.js
+++ b/src/kiri/core/init.js
@@ -1775,6 +1775,7 @@ function init_two() {
     $('mesh-export-stl').onclick = () => { objectsExport('stl') };
     $('mesh-export-obj').onclick = () => { objectsExport('obj') };
     $('mesh-merge').onclick = selection.merge;
+    $('mesh-split').onclick = selection.isolateBodies;
     $('context-duplicate').onclick = duplicateSelection;
     $('context-mirror').onclick = mirrorSelection;
     $('context-layflat').onclick = () => { api.event.emit("tool.mesh.lay-flat") };

--- a/web/kiri/index.html
+++ b/web/kiri/index.html
@@ -286,6 +286,7 @@
                 <div id="ft-mesh" class="grow f-col pop">
                     <div id="ft-mesh-btn">
                         <div><button id="mesh-merge" lk="rc_merg">Merge</button></div>
+                        <div><button id="mesh-split" lk="rc_splt">Isolate Bodies</button></div>
                         <div><button id="mesh-export-obj" lk="rc_xobj">export OBJ</button></div>
                         <div><button id="mesh-export-stl" lk="rc_xstl">export STL</button></div>
                     </div>

--- a/web/kiri/lang/en.js
+++ b/web/kiri/lang/en.js
@@ -78,6 +78,7 @@ self.lang['en-us'] = {
     rc_xstl:        "export STL",
     sb_info:        ["print speed","in mm/s"],
     rc_merg:        "merge object meshes",
+    rc_splt:        "isolate bodies",
 
     // DEVICE MENU and related dialogs
     dm_sldt:        "select a device type",


### PR DESCRIPTION
Adds a function to split widgets into their discreet components.

this will eliminate the pain point of having to delete and re-lay-out sheet-metal cut parts, after merging them for a drill operation.