### PR TITLE
Rough-cut-bugfix

### DIFF
--- a/src/kiri-mode/cam/ops.js
+++ b/src/kiri-mode/cam/ops.js
@@ -461,7 +461,7 @@ class OpRough extends CamOp {
             // set winding specified in output
             POLY.setWinding(level, cutdir, false);
             poly2polyEmit(level, printPoint, (poly, index, count) => {
-                printPoint = polyEmit(poly, index, count, printPoint);
+                printPoint = polyEmit(poly, index, count, printPoint, {cutFromLast: true});
             }); 
             newLayer();
         }

--- a/src/kiri-mode/cam/prepare.js
+++ b/src/kiri-mode/cam/prepare.js
@@ -745,11 +745,15 @@ function prepEach(widget, settings, print, firstPoint, update) {
      * @param {number} index - unused
      * @param {number} count - 1 to set engage factor
      * @param {Point} fromPoint - the point to rapid move from
-     * @param {Object} camOutOpts - optional parameters to pass to camOut
+     * @param {boolean} ops.cutFromLast - whether to emit a 1 when moving from last point. Defaults to false
      * @returns {Point} - the last point of the polygon
      */
-    function polyEmit(poly, index, count, fromPoint) {
-        
+    function polyEmit(poly, index, count, fromPoint,ops) {
+        let {
+            cutFromLast,
+        } = ops ?? {
+            cutFromLast: false
+        };
         let arcMax = Infinity, // no max arc radius
             lineTolerance = 0.001; // do not consider points under 0.001mm for arcs
 
@@ -785,7 +789,11 @@ function prepEach(widget, settings, print, firstPoint, update) {
             // if(offset == 0) console.log("forEachPoint",point,pidx,points)
             // console.log({pointA, pointB, indexA, indexB,startIndex})
             if(indexA == startIndex){
-                camOut(pointA.clone(), 0, {factor:engageFactor});
+                if(cutFromLast){
+                    camOut(pointA.clone(), 1, {factor:engageFactor});
+                }else{
+                    camOut(pointA.clone(), 0, {factor:engageFactor});
+                }
                 // if first point, move to and call export function
                 if (arcEnabled) quePush(pointA);
             }


### PR DESCRIPTION
Makes Rough op clearing above stock use G1s for cutting moves, not G0s.