### PR TITLE
Update "Z-Thru" Setting to be handled the same as the regular material thickness.

### DIFF
--- a/src/kiri/mode/cam/op-outline.js
+++ b/src/kiri/mode/cam/op-outline.js
@@ -33,7 +33,7 @@ class OpOutline extends CamOp {
             off: 0.01,
             fit: true,
             down: true,
-            min: Math.max(0, workarea.bottom_z),
+            min: workarea.bottom_z,
             max: workarea.top_z
         };
         let indices = slicer.interval(op.down, intopt);
@@ -97,18 +97,8 @@ class OpOutline extends CamOp {
             }
         }
 
-        // extend cut thru (only when z bottom is 0)
-        if (workarea.bottom_z < 0) {
-            let last = slices[slices.length-1];
-            for (let zneg of base_util.lerp(0, -workarea.bottom_cut, op.down)) {
-                if (!last) continue;
-                let add = last.clone(true);
-                add.tops.forEach(top => top.poly.setZ(add.z));
-                add.shadow = last.shadow.clone(true);
-                add.z -= zneg;
-                slices.push(add);
-            }
-        }
+        // z-thru depth is now handled by regular slicing using workarea.bottom_cut
+        // No separate z-thru slices needed
 
         slices.forEach(slice => {
             let tops = slice.shadow;

--- a/src/kiri/mode/cam/op-rough.js
+++ b/src/kiri/mode/cam/op-rough.js
@@ -77,7 +77,7 @@ class OpRough extends CamOp {
         let shadow = [];
         let slices = [];
         let indices = slicer.interval(roughDown, {
-            down: true, min: 0, fit: true, off: 0.01
+            down: true, min: workarea.bottom_z, fit: true, off: 0.01
         });
 
         // shift out first (top-most) slice
@@ -258,17 +258,8 @@ class OpRough extends CamOp {
 
         let last = slices[slices.length-1];
 
-        if (workarea.bottom_z < 0)
-        for (let zneg of base_util.lerp(0, -workarea.bottom_cut, op.down)) {
-            if (!last) continue;
-            let add = last.clone(true);
-            add.z -= zneg;
-            add.camLines = last.camLines.clone(true);
-            add.camLines.forEach(p => p.setZ(add.z + roughLeaveZ));
-            // add.tops.forEach(top => top.poly.setZ(add.z));
-            // add.shadow = last.shadow.clone(true);
-            slices.push(add);
-        }
+        // z-thru depth is now handled by regular slicing using workarea.bottom_cut
+        // No separate z-thru slices needed
 
         slices.forEach(slice => {
             slice.output()


### PR DESCRIPTION
Currently the padding added to the bottom of the part by the "Z-thru" setting is treated as a special case which is handled after the rest of the part is cut. This makes it impossible to cut parts in a single pass which have Z-thru set and generally leads to one extra pass per part which can add a lot of time.

This PR updates it to be handled the same as the regular part thinkness which improves efficiency. 

I believe that these changes are relatively surgical and won't impact any other parts of the program, but someone with a better understanding of the codebase should take a look to make sure they don't impact things in a way that I don't foresee.

<img width="990" height="590" alt="image" src="https://github.com/user-attachments/assets/019bedcf-43af-4bc7-9937-415d4ef71649" />

Fixes #421 