### PR TITLE
Improve routing between areas for CAM Area operations

### DIFF
--- a/src/kiri/mode/cam/work/op-area.js
+++ b/src/kiri/mode/cam/work/op-area.js
@@ -471,7 +471,8 @@ class OpArea extends CamOp {
         while (areas?.length) {
             let min = {
                 dist: Infinity,
-                area: undefined
+                area: undefined,
+                point: undefined
             };
 
             for (let area of areas.filter(p => !p.used)) {
@@ -486,12 +487,14 @@ class OpArea extends CamOp {
                 if (find.distance < min.dist) {
                     min.area = area;
                     min.dist = find.distance;
+                    min.point = find.point
                 }
             }
 
             // if we have a next-closest top poly, pocket that
             if (min.area) {
                 min.area.used = true;
+                printPoint = min.point;
                 pocket({
                     cutdir: op.ov_conv,
                     depthFirst: process.camDepthFirst,


### PR DESCRIPTION
The current behavior for CAM Area operations is that they are ordered by distance to the origin. This can result in inefficient pathing.

## Old behavior
![old](https://github.com/user-attachments/assets/451bc7d6-dea8-4148-a41a-6434c261afa0)

This change improves the pathing by updating the `printPoint` after every Area is processed, so that the next Area to be computed is determined based on its distance to the previous Area rather than the origin.

## New behavior
![new](https://github.com/user-attachments/assets/b2746ab0-e420-4fe9-b726-ac1971c18cd3)

