### PR TITLE
Limit framerate of preview animation

### DIFF
--- a/src/moto/space.js
+++ b/src/moto/space.js
@@ -1681,12 +1681,22 @@ let Space = {
 
         let animates = 0;
         let rateStart = Date.now();
-        let renderStart;
+        let lastRenderTime = 0;
         let renders = [];
 
+        const targetFrameRate = 1000 / 60;
+
         function animate() {
-            animates++;
+            requestAnimationFrame(animate);
+
             const now = Date.now();
+
+            const elapsed = now - lastRenderTime;
+            if (elapsed < targetFrameRate) return;
+            
+            lastRenderTime = now - (elapsed % targetFrameRate);
+            animates++;
+
             if (now - rateStart > 1000) {
                 // compute stats roughly every second
                 const delta = now - rateStart;
@@ -1697,9 +1707,9 @@ let Space = {
                 renderTime = Math.max(0, ...renders);
                 renders.length = 0;
             }
-            requestAnimationFrame(animate);
+
             if (docVisible && !freeze && Date.now() - lastAction < 1500) {
-                renderStart = Date.now();
+                const renderStart = Date.now();
                 renderer.render(SCENE, camera);
                 // track frame render times
                 renders.push(Date.now() - renderStart);

--- a/src/moto/space.js
+++ b/src/moto/space.js
@@ -1682,6 +1682,7 @@ let Space = {
         let animates = 0;
         let rateStart = Date.now();
         let lastRenderTime = 0;
+        let renderStart;
         let renders = [];
 
         const targetFrameRate = 1000 / 60;
@@ -1709,7 +1710,7 @@ let Space = {
             }
 
             if (docVisible && !freeze && Date.now() - lastAction < 1500) {
-                const renderStart = Date.now();
+                renderStart = Date.now();
                 renderer.render(SCENE, camera);
                 // track frame render times
                 renders.push(Date.now() - renderStart);


### PR DESCRIPTION
Limits the framerate of the animation loop for consistent playback speeds regardless of monitor refresh rate. 

Video of the problem:
https://github.com/user-attachments/assets/53cab964-2502-4b25-8510-e5e6b6173811

I was only able to test this on a 60Hz monitor since that's all I have for my Linux machine. That said, I did throw together [this codepen](https://codepen.io/dylangggg/pen/KwgyNLb) with a vertical slice of relevant code and saw 60fps regardless of refresh rate.