### PR TITLE
feat: add speed controls to the animation player

### DIFF
--- a/src/kiri/mode/cam/app/anim-2d.js
+++ b/src/kiri/mode/cam/app/anim-2d.js
@@ -53,7 +53,9 @@ export function animate(api, delay) {
             speed: anim.speed,
             trans: anim.trans,
             model: anim.model,
-            shade: anim.shade
+            shade: anim.shade,
+            speedup: anim.speedup,
+            speeddn: anim.speeddn,
         });
         Object.assign(label, {
             progress: anim.progress,
@@ -76,6 +78,8 @@ export function animate(api, delay) {
         button.trans.onclick = toggleTrans;
         button.model.onclick = toggleModel;
         button.shade.onclick = toggleStock;
+        button.speedup.onclick = increaseSpeed;
+        button.speeddn.onclick = decreaseSpeed;
         button.play.style.display = '';
         button.pause.style.display = 'none';
 
@@ -175,6 +179,14 @@ function toggleStock(ev,bool,set) {
     return api.event.emit('cam.stock.toggle', bool ?? undefined);
 }
 
+function increaseSpeed() {
+    updateSpeed(1);
+}
+
+function decreaseSpeed() {
+    updateSpeed(-1);
+}
+
 function toggleTrans(ev,bool) {
     bool = api.local.toggle('cam.anim.trans', bool);
     material.transparent = bool;
@@ -228,8 +240,8 @@ function handleGridUpdate(data) {
 function updateSpeed(inc = 0) {
     if (inc === Infinity) {
         speedIndex = speedMax;
-    } else if (inc > 0) {
-        speedIndex = (speedIndex + inc) % speedValues.length;
+    } else if (inc !== 0) {
+        speedIndex = Math.min(Math.max(speedIndex + inc, 0), speedValues.length - 1);
     }
     api.local.set('cam.anim.speed', speedIndex);
     speed = speedValues[speedIndex];

--- a/src/kiri/mode/cam/app/init-menu.js
+++ b/src/kiri/mode/cam/app/init-menu.js
@@ -99,6 +99,10 @@ export function menu() {
             anim.step     = newButton(null,"anim.step",{icon:'<i class="fas fa-step-forward"></i>',title:"single step"}),
             anim.speed    = newButton(null,"anim.fast",{icon:'<i class="fas fa-forward"></i>',title:"toggle speed"}),
             anim.labspd   = newValue(3, {class:"center padleft"}),
+            newRow([
+                anim.speedup = newButton(null,'anim.speedup',{icon:'<i class="fa-solid fa-arrow-up"></i>',title:"increase speed"}),
+                anim.speeddn = newButton(null,'anim.speeddn',{icon:'<i class="fa-solid fa-arrow-down"></i>',title:"decrease speed"})
+            ], {class: 'speed-controls padleft'}),
             anim.labx     = newLabel("X", {class:"padleft"}),
             anim.valx     = newValue(7, {class:"center"}),
             anim.laby     = newLabel("Y", {class:"padleft"}),

--- a/web/kiri/index.css
+++ b/web/kiri/index.css
@@ -2155,6 +2155,7 @@ details[open] summary::after {
 }
 #layer-animate .speed-controls {
     flex-direction: column;
+    justify-content: space-between;
 }
 #layer-animate .speed-controls button {
     width: auto;

--- a/web/kiri/index.css
+++ b/web/kiri/index.css
@@ -2153,6 +2153,16 @@ details[open] summary::after {
     color: #333;
     font-size: 30px;
 }
+#layer-animate .speed-controls {
+    flex-direction: column;
+}
+#layer-animate .speed-controls button {
+    width: auto;
+    padding: 0 4px;
+}
+#layer-animate .speed-controls svg {
+    font-size: 15px;
+}
 #layer-animate .padleft {
     margin-left: 8px !important;
 }


### PR DESCRIPTION
Adds some basic arrow controls to increase and decrease the playback speed of the animation player. I am new to using this app so sorry if there is already a way to change this value but I wasn't able to figure it out.

<img width="821" height="52" alt="image" src="https://github.com/user-attachments/assets/c24ee625-c27c-483c-a229-8758b81865ff" />

I only added this for `anim-2d.js` since that seemed to control the animation tab in CAM mode. I could also update `anim-3d.js`, just wasn't sure where it lived on the page.

https://github.com/user-attachments/assets/1de325ca-df24-4094-896a-32988a722d5d

