### PR TITLE
Basic Finish Cut Capability

### DIFF
--- a/src/kiri/mode/cam/app/cl-ops.js
+++ b/src/kiri/mode/cam/app/cl-ops.js
@@ -778,6 +778,7 @@ export function createPopOps() {
         revbones: 'camAreaRevbones',
         ov_topz: 0,
         ov_botz: 0,
+        finish_cut: 0,
     }).inputs = {
         mode: UC.newSelect(LANG.mo_menu, { post: opRender }, "opmode"),
         tr_type: UC.newSelect(LANG.cc_offs_s, { title: LANG.cc_offs_l, show: isTrace }, "traceoff"),
@@ -805,6 +806,7 @@ export function createPopOps() {
         sr_angle: UC.newInput(LANG.ca_sang_s, { title: LANG.ca_sang_l, convert: toFloat, bound: UC.bound(0, 360), show: isSurfaceLinear }),
         over: UC.newInput(LANG.cc_sovr_s, { title: LANG.cc_sovr_l, convert: toFloat, bound: UC.bound(0.001, 100.0), show: () => isClear() || isSurface() }),
         down: UC.newInput(LANG.cc_sdwn_s, { title: LANG.cc_sdwn_l, convert: toFloat, bound: UC.bound(0, 100.0), units, show: () => isClear() || isTrace() }),
+        finish_cut: UC.newInput("finish cut", { title: "finish cut", convert: toFloat, bound: UC.bound(0, 2.0), units, show: () => isClear() || isTrace() }), //todo: needs to check camInnerFirst
         refine: UC.newInput(LANG.cp_refi_s, { title: LANG.cp_refi_l, convert: toInt, show: isSurface }),
         sr_alter: UC.newBoolean(LANG.ca_altr_s, undefined, { title: LANG.ca_altr_l, show: isSurfaceLinear }),
         dogbones: UC.newBoolean(LANG.co_dogb_s, undefined, { title: LANG.co_dogb_l, show: isTrace }),

--- a/src/kiri/mode/cam/app/cl-ops.js
+++ b/src/kiri/mode/cam/app/cl-ops.js
@@ -806,7 +806,7 @@ export function createPopOps() {
         sr_angle: UC.newInput(LANG.ca_sang_s, { title: LANG.ca_sang_l, convert: toFloat, bound: UC.bound(0, 360), show: isSurfaceLinear }),
         over: UC.newInput(LANG.cc_sovr_s, { title: LANG.cc_sovr_l, convert: toFloat, bound: UC.bound(0.001, 100.0), show: () => isClear() || isSurface() }),
         down: UC.newInput(LANG.cc_sdwn_s, { title: LANG.cc_sdwn_l, convert: toFloat, bound: UC.bound(0, 100.0), units, show: () => isClear() || isTrace() }),
-        finish_cut: UC.newInput("finish cut", { title: "finish cut", convert: toFloat, bound: UC.bound(0, 2.0), units, show: () => isClear() || isTrace() }), //todo: needs to check camInnerFirst
+        finish_cut: UC.newInput("finish cut", { title: "finish cut", convert: toFloat, bound: UC.bound(0, 2.0), units, show: () => isClear() }), //todo: needs to check camInnerFirst
         refine: UC.newInput(LANG.cp_refi_s, { title: LANG.cp_refi_l, convert: toInt, show: isSurface }),
         sr_alter: UC.newBoolean(LANG.ca_altr_s, undefined, { title: LANG.ca_altr_l, show: isSurfaceLinear }),
         dogbones: UC.newBoolean(LANG.co_dogb_s, undefined, { title: LANG.co_dogb_l, show: isTrace }),

--- a/src/kiri/mode/cam/work/op-area.js
+++ b/src/kiri/mode/cam/work/op-area.js
@@ -207,7 +207,7 @@ class OpArea extends CamOp {
                     //everything else uses the tool stepover
                     offsets.push(-toolOver);
                     //actually offset the walls inwards
-                    POLY.offset(clip, [ firstOff, -finish_cut, -toolOver ], {
+                    POLY.offset(clip, offsets, {
                         count: op.walls ? 1 : (op.steps ?? 999), outs, flat: true, z: z - zMov, ...offopt
                     });
                     // if we see no offsets, re-check the mesh bottom Z then exit

--- a/src/kiri/mode/cam/work/op-area.js
+++ b/src/kiri/mode/cam/work/op-area.js
@@ -197,7 +197,17 @@ class OpArea extends CamOp {
                     } else {
                         POLY.subtract([ area ], shadow, clip, undefined, undefined, 0);
                     }
-                    POLY.offset(clip, [ firstOff, -toolOver ], {
+                    //generate offsets to use
+                    let offsets = [ firstOff ];
+                    //if we need a finish cut, add it
+                    let finish_cut = op.finish_cut ?? 0;
+                    if (finish_cut != 0) { //todo: this should check for camInnerFirst and warn if it is not true
+                        offsets.push(-finish_cut);
+                    }
+                    //everything else uses the tool stepover
+                    offsets.push(-toolOver);
+                    //actually offset the walls inwards
+                    POLY.offset(clip, [ firstOff, -finish_cut, -toolOver ], {
                         count: op.walls ? 1 : (op.steps ?? 999), outs, flat: true, z: z - zMov, ...offopt
                     });
                     // if we see no offsets, re-check the mesh bottom Z then exit


### PR DESCRIPTION
As discussed on discord; basic finish cut capability and UI work to make it functional.

Finish cuts are very helpful in metal or less rigid machines to achieve suitable tolerances. A separate operation may also be performed of course, but for many cuts the approach as-is will be sufficient and it saves configuring an op.

There are a few todos still in the code, mainly around it only making any sense with inner-first cuts, for pockets at least. I'm not sure how best to detect or warn about that.