### PR TITLE
fix: add missing build steps to Dockerfile

### DIFF
--- a/src/dock/Dockerfile
+++ b/src/dock/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-slim
+FROM node:22-slim
 WORKDIR /grid
 COPY package.json /grid
 COPY app.js /grid
@@ -6,9 +6,11 @@ COPY apps /grid/apps
 COPY src /grid/src
 COPY web /grid/web
 COPY bin /grid/bin
-RUN apt-get -y update; apt-get -y install curl
+RUN apt-get -y update; apt-get -y install curl git
 EXPOSE 8080
 RUN npm i
+RUN npm run webpack-ext
 RUN npm install -g @gridspace/app-server
+RUN npm run pack-prod
 RUN rm -rf /grid/bin
 CMD gs-app-server


### PR DESCRIPTION
## Context

Looking at the README, the intended Docker workflow is `npm run setup` on the host first, then `docker-compose up`. This works well if you have Node.js installed on the host - the setup step builds the ext files and bundles, and the Dockerfile copies them into the image.

However, for use cases where Node isn't available on the host - TrueNAS deployments (which the README also documents), standalone Docker hosts, NAS devices, Raspberry Pis - the Dockerfile needs to be self-contained. This PR adds the missing build steps so the image can be built directly from a fresh clone without any host-side prerequisites.

## Changes (Dockerfile only - 4 lines changed)

| Change | Why |
|--------|-----|
| `node:18-slim` → `node:22-slim` | `package.json` declares `engines.node >= 22`; Node 18 can't parse the ES module syntax used at runtime |
| Add `git` to `apt-get install` | Some npm dependencies pull from git repos during install |
| Add `RUN npm run webpack-ext` | Creates `ext/three.js` and `ext/jszip-esm.js` that the production build depends on |
| Add `RUN npm run pack-prod` | Compiles all JS/CSS into `src/pack/` - the main missing piece that was previously handled by `npm run setup` on the host |

## What was happening

    docker compose -f src/dock/compose.yml up
    # Container starts, logs show:
    #   'missing' 'apps/grid/src/pack/mesh-main.js'
    #   'missing' 'apps/grid/src/pack/kiri-main.js'
    #   'app-server running: ports=[8080]'
    # Browser shows "Kiri:Moto is Loading" forever - JS bundles 404.

This also affects the TrueNAS YAML deployment path documented in the README, which builds directly from the repo without a host setup step.

## Test results

| Test | ARM64 (Pi 4, Docker 29.4) | x86_64 (Proxmox, Docker 20.10) |
|------|---------------------------|--------------------------------|
| Docker build succeeds | ✅ | ✅ |
| Server starts, 0 "missing" warnings | ✅ | ✅ |
| GET /kiri/ → 200 | ✅ (25,878 bytes) | ✅ (25,878 bytes) |
| GET /lib/main/kiri.js → 200 | ✅ (4,119,046 bytes) | ✅ (4,119,046 bytes) |
| npm run setup && npm run dryrun-prod | ✅ exit 0 | ✅ exit 0 |
| Bundle sizes match across architectures | ✅ identical | ✅ identical |

Regression confirmed: the unpatched Dockerfile fails at npm i (missing git, exit 254).

## Suggestion: Docker CI workflow

We also prepared a docker-test.yml GitHub Actions workflow that builds the image and verifies the app loads on every push to src/dock/. Couldn't include it in this PR due to OAuth scope limitations, but happy to submit it separately if useful.

## Environment

- Raspberry Pi 4 (8GB), ARM64, Raspberry Pi OS Bookworm, Docker 29.4.0
- Proxmox VE 8.x, x86_64, Debian 12, Docker 20.10.24
- Node 22.22.2 (inside container)

Thank you for Kiri:Moto - we're running it self-hosted for our 3D printing workflow and it's excellent. Happy to help with any follow-up.