### PR TITLE
fix: add missing await on mkdir and node:module external in esbuild config

### DIFF
--- a/bin/esbuild.config.mjs
+++ b/bin/esbuild.config.mjs
@@ -57,7 +57,7 @@ async function generateDevices(dir = '') {
         }
     }
     let dstr = JSON.stringify(devs);
-    fs.mkdir(path.join(dir, "src", "pack"), { recursive: true });
+    await fs.mkdir(path.join(dir, "src", "pack"), { recursive: true });
     await fs.writeFile(path.join(dir, "src", "pack", "kiri-devs.js"), `export const devices = ${dstr};`);
     if (true) {
         // create alt artifacts
@@ -77,6 +77,7 @@ const rec = {
     define: { 'process.env.NODE_ENV': `"${mode}"` },
     external: [
         'module',
+        'node:module',
         './constants',
         './voronoi_structures',
         './voronoi_ctypes',


### PR DESCRIPTION
## Summary

Two small fixes in `bin/esbuild.config.mjs` that cause build failures in certain environments.

## Changes (2 lines)

### 1. Add missing `await` on `fs.mkdir()` (line 60)

```diff
-    fs.mkdir(path.join(dir, "src", "pack"), { recursive: true });
+    await fs.mkdir(path.join(dir, "src", "pack"), { recursive: true });
```

The `fs.mkdir` call in `generateDevices()` returns a Promise that was being silently dropped. The `fs.writeFile()` on the very next line can fire before the directory exists, producing an `ENOENT` error. This is a race condition - it may succeed on fast machines where the mkdir Promise resolves before writeFile starts, but fails reliably on slower hardware or under load.

Note: the `alt/pack` mkdir on line 64 already has `await` correctly.

### 2. Add `'node:module'` to esbuild externals

```diff
     external: [
         'module',
+        'node:module',
         './constants',
```

The bare specifier `'module'` was already listed, but esbuild treats `node:module` (the Node.js prefixed form introduced in Node 16+) as a separate identifier. Without this, production builds fail with:

```
✘ [ERROR] Could not resolve "node:module"
  The package "node:module" wasn't found on the file system but is built into node.
```

## Test results

| Test | ARM64 (Pi 4) | x86_64 (Proxmox) |
|------|-------------|-------------------|
| `npm run setup && npm run dryrun-prod` | :white_check_mark: exit 0 | :white_check_mark: exit 0 |
| `npm run pack-prod` | :white_check_mark: "Build completed successfully in prod mode!" | :white_check_mark: |
| Bundle sizes identical across architectures | :white_check_mark: | :white_check_mark: |

Both changes are additive/correctness fixes - they should not affect any working build. The `await` makes an async call correct that was previously relying on a race. The external entry tells esbuild to skip bundling a Node builtin that it was already failing to resolve.