### PR TITLE
fix: add missing build steps and update Node in Dockerfile

### DIFF
--- a/src/dock/Dockerfile
+++ b/src/dock/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-slim
+FROM node:22-slim
 WORKDIR /grid
 COPY package.json /grid
 COPY app.js /grid
@@ -6,9 +6,12 @@ COPY apps /grid/apps
 COPY src /grid/src
 COPY web /grid/web
 COPY bin /grid/bin
-RUN apt-get -y update; apt-get -y install curl
+RUN apt-get -y update; apt-get -y install curl git
 EXPOSE 8080
 RUN npm i
+RUN npm run webpack-ext
+RUN mkdir -p src/pack
+RUN npm run pack-prod
 RUN npm install -g @gridspace/app-server
 RUN rm -rf /grid/bin
 CMD gs-app-server


### PR DESCRIPTION
## Summary

Re-targeted from #476 to `rel-next` as requested.

- Update base image from node:18-slim to node:22-slim (matching package.json engines requirement)
- Add git to apt-get install (needed by npm dependencies)
- Add webpack-ext step (builds external bundles required by esbuild)
- Add mkdir -p src/pack (prevents race condition on clean builds)
- Add pack-prod step (builds application bundles)
- Reorder: build steps run before gs-app-server global install

Without these changes, the container starts but serves an incomplete app that never finishes loading - the JS bundles in src/pack/ are never built.

## Test environment

- ARM64: Raspberry Pi 4 (8GB), Pi OS Bookworm, Docker 29.4.0, Node 22
- x86_64: Ubuntu 24.04 (Proxmox LXC), Docker 28.0.4, Node 22
- Both: clean clone, docker compose build, verified /kiri/ loads and slices

## Test plan

- [ ] `docker compose build` completes without error
- [ ] Container starts and /kiri/ returns 200
- [ ] /lib/pack/kiri-main.js returns 200 with non-empty content
- [ ] Slicer UI loads fully in browser
- [ ] Import STL and slice produces gcode