### PR TITLE
fix: add missing await on mkdir and node:module external in esbuild config

### DIFF
--- a/bin/esbuild.config.mjs
+++ b/bin/esbuild.config.mjs
@@ -57,7 +57,7 @@ async function generateDevices(dir = '') {
         }
     }
     let dstr = JSON.stringify(devs);
-    fs.mkdir(path.join(dir, "src", "pack"), { recursive: true });
+    await fs.mkdir(path.join(dir, "src", "pack"), { recursive: true });
     await fs.writeFile(path.join(dir, "src", "pack", "kiri-devs.js"), `export const devices = ${dstr};`);
     if (true) {
         // create alt artifacts
@@ -77,6 +77,7 @@ const rec = {
     define: { 'process.env.NODE_ENV': `"${mode}"` },
     external: [
         'module',
+        'node:module',
         './constants',
         './voronoi_structures',
         './voronoi_ctypes',


### PR DESCRIPTION
## Summary

Re-targeted from #477 to `rel-next` as requested.

- Add `await` to `fs.mkdir()` in `generateDevices()` (line 60). Without this, `writeFile` can race ahead of directory creation, causing ENOENT on clean builds or slower I/O.
- Add `'node:module'` to the externals array. Node.js treats `'module'` and `'node:module'` as distinct specifiers - esbuild fails to resolve the prefixed form when bundling for the browser target.

## Test environment

- ARM64: Raspberry Pi 4 (8GB), Pi OS Bookworm, Node 22
- x86_64: Ubuntu 24.04 (Proxmox LXC), Node 22
- Both: npm run setup && npm run dryrun-prod pass cleanly

## Test plan

- [ ] `npm run setup` completes without error
- [ ] `npm run dryrun-prod` completes without error
- [ ] src/pack/ directory contains all expected bundle files
- [ ] No ENOENT errors on clean build with empty src/pack/