### PR TITLE
fix: rewrite CLI to use esbuild bundle output

### DIFF
--- a/src/kiri/run/cli.js
+++ b/src/kiri/run/cli.js
@@ -1,6 +1,12 @@
 /** Copyright Stewart Allen <sa@grid.space> -- All Rights Reserved */
 
-/** updated to use esbuild bundle output instead of eval-based gapp loader */
+/**
+ * updated to use esbuild bundle output instead of eval-based gapp loader.
+ * runs single-threaded with an in-process Worker message bridge.
+ *
+ * supported: FDM, LASER, SLA modes (single-threaded slicing)
+ * limited:   CAM mode (requires worker pool for parallel ops - not yet wired)
+ */
 
 import fs from 'fs';
 import path from 'path';
@@ -137,11 +143,24 @@ globalThis.fetch = function(url) {
     }
 };
 
-// suppress async errors from optional wasm modules (manifold-3d)
+// intercept fs.readFileSync to redirect wasm lookups to src/wasm/
+let _readFileSync = fs.readFileSync;
+fs.readFileSync = function(filepath, ...args) {
+    if (typeof filepath === 'string' && filepath.endsWith('.wasm') && !fs.existsSync(filepath)) {
+        let wasmName = path.basename(filepath);
+        let wasmPath = path.join(root, 'src/wasm', wasmName);
+        if (_readFileSync.call(fs, wasmPath, ...args)) {
+            filepath = wasmPath;
+        }
+    }
+    return _readFileSync.call(fs, filepath, ...args);
+};
+
+// suppress async errors from optional wasm modules
 process.on('unhandledRejection', () => {});
 process.on('uncaughtException', (err) => {
     if (err && err.message && err.message.includes('Aborted')) return;
-    process.stderr.write(err.stack || err.message || String(err));
+    process.stderr.write((err.stack || err.message || String(err)) + '\n');
     process.exit(1);
 });
 process.abort = noop;
@@ -236,6 +255,7 @@ async function run() {
             }
         })
         .then(() => { if (device.mode) engine.setMode(device.mode) })
+        .then(() => engine.setController({ threaded: false }))
         .then(() => engine.setDevice(device))
         .then(() => engine.setProcess(procset))
         .then(() => { if (device.mode === 'CAM') engine.setTools(tools) })

--- a/src/kiri/run/cli.js
+++ b/src/kiri/run/cli.js
@@ -235,10 +235,10 @@ async function run() {
                 engine.rotate(x,y,z);
             }
         })
+        .then(() => { if (device.mode) engine.setMode(device.mode) })
         .then(() => engine.setDevice(device))
         .then(() => engine.setProcess(procset))
         .then(() => { if (device.mode === 'CAM') engine.setTools(tools) })
-        .then(() => { if (device.mode) engine.setMode(device.mode) })
         .then(eng => engine.slice())
         .then(eng => engine.prepare())
         .then(eng => engine.export())

--- a/src/kiri/run/cli.js
+++ b/src/kiri/run/cli.js
@@ -1,11 +1,16 @@
-/** example of how to use Kiri:Moto's slicer engine from the command-line */
-let fs = require('fs');
+/** Copyright Stewart Allen <sa@grid.space> -- All Rights Reserved */
+
+/** updated to use esbuild bundle output instead of eval-based gapp loader */
+
+import fs from 'fs';
+import path from 'path';
+
 let args = process.argv.slice(2);
+let root = path.resolve(import.meta.dirname, '../../..');
 let opts = {
-    dir: process.cwd(),
+    dir: root,
     output: "-",
     model: "web/obj/cube.stl",
-    source: "src/cli/kiri-source.json",
     controller: "src/cli/kiri-controller.json",
     process: "src/cli/kiri-fdm-process.json",
     device: "src/cli/kiri-fdm-device.json",
@@ -36,10 +41,9 @@ if (opts.help) {
     console.log([
         "cli <options> <file>",
         "   --verbose           | enable verbose logging",
-        "   --dir=[dir]         | root directory for file paths (default: '.')",
+        "   --dir=[dir]         | root directory for file paths (default: repo root)",
         "   --model=[file]      | model file to load (or last parameter)",
         "   --tools=[file]      | tools array for CAM mode",
-        "   --source=[file]     | source file list (defaults to kiri engine)",
         "   --device=[file]     | device definition file (json)",
         "   --process=[file]    | process definition file (json)",
         "   --controller=[file] | controller definition file (json)",
@@ -49,137 +53,163 @@ if (opts.help) {
         "   --scale=x,y,z       | scale loaded model in x,y,z",
         "   --move=x,y,z        | move loaded model x,y,z millimeters"
     ].join("\r\n"));
-    return;
+    process.exit(0);
 }
 
 let { dir, verbose, model, output, position, move, scale, rotate } = opts;
-let exports_save = exports,
-    navigator = { userAgent: "" },
-    module_save = module,
-    THREE = {},
-    gapp = {},
-    geo = {},
-    noop = () => { },
-    self = this.self = {
-        gapp,
-        THREE,
-        location: { hostname: 'local', port: 0, protocol: 'fake' },
-        postMessage: (msg) => {
-            self.kiri.client.onmessage({data:msg});
-        }
-    };
 
-// fake fetch for worker to get wasm, if needed
-let fetch = function(url, opts = {}) {
-    if (verbose) console.log({fetch: url});
-    if (!url.startsWith('/')) {
-        url = `${dir}/${url}`;
+// resolve paths relative to dir
+function resolve(file) {
+    if (path.isAbsolute(file)) return file;
+    return path.join(dir, file);
+}
+
+// read json config file (supports trailing commas like the cli configs)
+function readJSON(file) {
+    let raw = fs.readFileSync(resolve(file)).toString();
+    // strip trailing commas before } or ] (relaxed json)
+    raw = raw.replace(/,\s*([\]}])/g, '$1');
+    return JSON.parse(raw);
+}
+
+// node is missing browser globals used during bundle import
+let noop = () => {};
+let mockCtx = new Proxy({}, { get: (t, p) => typeof p === 'symbol' ? undefined : () => mockCtx });
+let mockEl = () => ({
+    getContext: () => mockCtx, style: {}, appendChild: noop,
+    addEventListener: noop, setAttribute: noop, removeEventListener: noop,
+    classList: { add: noop, remove: noop, contains: () => false },
+    width: 256, height: 256, getBoundingClientRect: () => ({}),
+    querySelector: () => null, querySelectorAll: () => [],
+    innerHTML: '', insertBefore: noop, removeChild: noop, contains: () => false
+});
+
+globalThis.self = globalThis;
+globalThis.window = globalThis;
+globalThis.navigator = { userAgent: 'node', hardwareConcurrency: 0, language: 'en-US' };
+globalThis.location = { hostname: 'localhost', port: 0, protocol: 'file:', search: '', hash: '', host: 'localhost', href: 'http://localhost/' };
+globalThis.document = {
+    createElement: mockEl, createElementNS: () => mockEl(),
+    addEventListener: noop, body: { appendChild: noop, style: {}, contains: () => false },
+    head: { appendChild: noop }, querySelectorAll: () => [],
+    getElementById: () => null, documentElement: { style: {} }
+};
+globalThis.HTMLCanvasElement = class {};
+globalThis.requestAnimationFrame = (cb) => setTimeout(cb, 16);
+globalThis.cancelAnimationFrame = noop;
+globalThis.WebSocket = class { addEventListener() {} close() {} send() {} };
+globalThis.XMLHttpRequest = class { open() {} send() {} setRequestHeader() {} };
+globalThis.Blob = class { constructor() {} };
+globalThis.URL.createObjectURL = () => 'blob:fake';
+globalThis.URL.revokeObjectURL = noop;
+globalThis.ResizeObserver = class { observe() {} disconnect() {} };
+globalThis.MutationObserver = class { observe() {} disconnect() {} };
+globalThis.getComputedStyle = () => new Proxy({}, { get: () => '' });
+globalThis.matchMedia = () => ({ matches: false, addEventListener: noop });
+globalThis.localStorage = { getItem: () => null, setItem: noop, removeItem: noop };
+globalThis.sessionStorage = { getItem: () => null, setItem: noop };
+globalThis.DOMParser = class { parseFromString() { return { querySelector: () => null, querySelectorAll: () => [] } } };
+globalThis.Image = class { set src(v) {} addEventListener() {} };
+globalThis.indexedDB = null;
+globalThis.atob = (a) => Buffer.from(a, 'base64').toString('binary');
+globalThis.btoa = (b) => Buffer.from(b, 'binary').toString('base64');
+
+// fake fetch reads files from disk, resolving paths relative to repo root
+globalThis.fetch = function(url) {
+    if (typeof url !== 'string') return Promise.resolve({ ok: false });
+    // handle relative paths from bundle location (e.g. '../wasm/manifold.wasm')
+    if (url.startsWith('../') || url.startsWith('./')) {
+        url = path.resolve(root, 'src/pack', url);
+    } else if (!path.isAbsolute(url) && !url.startsWith('http')) {
+        url = resolve(url);
     }
-    let buf = fs.readFileSync(url);
-    return new Promise((resolve, reject) => {
-        resolve(new Promise((resolve, reject) => {
-            if (opts.format === 'string') {
-                return resolve(buf.toString());
-            }
-            if (opts.format === 'buffer') {
-                return resolve(buf);
-            }
-            if (opts.format === 'eval') {
-                return resolve(eval('(' + buf + ')'));
-            }
-            resolve({
-                arrayBuffer: function() {
-                    return buf;
-                }
-            });
-        }));
+    if (verbose) console.log({fetch: url});
+    try {
+        let buf = fs.readFileSync(url);
+        return Promise.resolve({
+            ok: true,
+            arrayBuffer: () => Promise.resolve(buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength)),
+            text: () => Promise.resolve(buf.toString()),
+            json: () => Promise.resolve(JSON.parse(buf.toString()))
+        });
+    } catch (e) {
+        return Promise.resolve({ ok: false });
+    }
+};
+
+// suppress async errors from optional wasm modules (manifold-3d)
+process.on('unhandledRejection', () => {});
+process.on('uncaughtException', (err) => {
+    if (err && err.message && err.message.includes('Aborted')) return;
+    process.stderr.write(err.stack || err.message || String(err));
+    process.exit(1);
+});
+process.abort = noop;
+
+// imitate worker process using in-process message bridge
+// tracks all workers so pool minions don't steal the main channel
+let workerOnMessage = null;
+let workers = [];
+
+globalThis.Worker = class {
+    constructor(url) {
+        if (verbose) console.log({worker: url});
+        this.onmessage = null;
+        this._id = workers.length;
+        workers.push(this);
+    }
+    postMessage(msg, xfer) {
+        // pool management messages (cmd) are not handled by the worker
+        if (msg && msg.cmd) return;
+        setImmediate(() => { if (workerOnMessage) workerOnMessage({ data: msg }) });
+    }
+    terminate() {}
+    addEventListener(type, fn) {
+        if (type === 'message') {
+            this.onmessage = (e) => fn(e);
+        }
+    }
+};
+
+// worker calls postMessage to send results back to the main worker (first created)
+globalThis.postMessage = function(msg, xfer) {
+    setImmediate(() => {
+        let w = workers[0];
+        if (w && w.onmessage) w.onmessage({ data: msg });
     });
 };
 
-// imitate worker process
-class Worker {
-    constructor(url) {
-        if (verbose) console.log({worker: url});
-    }
+globalThis.createWorker = () => new Worker();
 
-    postMessage(msg) {
-        setImmediate(() => {
-            self.kiri.worker.onmessage({data:msg});
-        });
-    }
+// redirect console.log to stderr so stdout stays clean for gcode piping
+let _log = console.log;
+console.log = (...args) => {
+    if (verbose) process.stderr.write(args.map(a => typeof a === 'object' ? JSON.stringify(a) : a).join(' ') + '\n');
+};
 
-    onmessage(msg) {
-        // if we end up here, something went wrong
-        console.trace('worker-recv', msg);
-    }
+// load worker bundle first to register message handler
+await import(root + '/src/pack/kiri-work.js').catch(() => {});
+workerOnMessage = self.onmessage;
 
-    terminate() {
-        // if we end up here, something went wrong
-        console.trace('worker terminate');
-    }
-}
-
-// node is missing these functions so put them in scope during eval
-function atob(a) {
-    return Buffer.from(a).toString('base64');
-}
-
-function btoa(b) {
-    return Buffer.from(b, 'base64').toString();
-}
+// load engine bundle
+let { newEngine } = await import(root + '/src/pack/kiri-eng.js');
 
 async function run() {
-    let files = await fetch(opts.source, { format: "eval" } );
-    let tools = await fetch(opts.tools, { format: "eval" } );
-    let device = await fetch(opts.device, { format: "eval" } );
-    let process = await fetch(opts.process, { format: "eval" } );
+    let tools = readJSON(opts.tools);
+    let device = readJSON(opts.device);
+    let procset = readJSON(opts.process);
+    let controller = readJSON(opts.controller);
 
-    for (let file of files.map(p => `${dir}/src/${p}.js`)) {
-        let isPNG = file.indexOf("/pngjs") > 0;
-        let isClip = file.indexOf("/clip") > 0;
-        let isEarcut = file.indexOf("/earcut") > 0;
-        let isTHREE = file.indexOf("/three") > 0;
-        if (isTHREE) {
-            // THREE.js kung-fu fake-out
-            exports = {};
-        }
-        let swapMod = isEarcut;
-        if (swapMod) {
-            module = { exports: {} };
-        }
-        let clearMod = isPNG || isClip;
-        if (clearMod) {
-            module = undefined;
-        }
-        try {
-            if (verbose) console.log(`loading ... ${file}`);
-            eval(fs.readFileSync(`${file}`).toString());
-        } catch (e) {
-            throw e;
-        }
-        if (isClip) {
-            ClipperLib = self.ClipperLib;
-        }
-        if (isTHREE) {
-            Object.assign(THREE, exports);
-            // restore exports after faking out THREE.js
-            exports = exports_save;
-        }
-        if (isEarcut) {
-            self.earcut = module.exports;
-        }
-        if (clearMod || swapMod) {
-            module = module_save;
-        }
+    let engine = newEngine();
+    engine.setController({ threaded: false });
+
+    let modelPath = resolve(model);
+    if (!fs.existsSync(modelPath)) {
+        process.stderr.write(`model not found: ${modelPath}\n`);
+        process.exit(1);
     }
-
-    let { kiri, moto, load } = self;
-
-    console.log({version: kiri.version});
-
-    let engine = kiri.newEngine();
-    let data = await fetch(model)
-    let buf = new Uint8Array(data.arrayBuffer()).buffer;
+    let data = fs.readFileSync(modelPath);
+    let buf = new Uint8Array(data).buffer;
 
     return engine.parse(buf)
         .then(data => { if (verbose) console.log({loaded: data}) })
@@ -206,21 +236,25 @@ async function run() {
             }
         })
         .then(() => engine.setDevice(device))
-        .then(() => engine.setProcess(process))
+        .then(() => engine.setProcess(procset))
         .then(() => { if (device.mode === 'CAM') engine.setTools(tools) })
-        .then(() => engine.setMode(device.mode))
-        .then(eng => eng.slice())
-        .then(eng => eng.prepare())
+        .then(() => { if (device.mode) engine.setMode(device.mode) })
+        .then(eng => engine.slice())
+        .then(eng => engine.prepare())
         .then(eng => engine.export())
         .then(gcode => {
             if (output === '-') {
-                console.log({gcode});
+                process.stdout.write(gcode);
             } else {
-                fs.writeFileSync(output, gcode);
+                let outpath = resolve(output);
+                fs.writeFileSync(outpath, gcode);
+                process.stderr.write(`wrote ${gcode.length} bytes to ${outpath}\n`);
             }
+            process.exit(0);
         })
         .catch(error => {
-            console.log({error});
+            process.stderr.write(JSON.stringify({error}) + '\n');
+            process.exit(1);
         });
 }
 


### PR DESCRIPTION
## Summary

Rewrites `src/kiri/run/cli.js` to use the pre-built esbuild bundles (`kiri-eng.js` + `kiri-work.js`) instead of the removed `gapp.js` eval-based loader. Same CLI interface, same in-process Worker bridge pattern, same single-threaded execution model as the original.

Follows up on #478 and #479 (Docker + esbuild build fixes) which made the bundles reliable to produce. With those merged, the CLI can consume the bundles directly as read-only build output.

## Commits

1. **fix: update CLI to use esbuild bundle output** (cd944a2f) — the core rewrite
2. **fix: correct setMode order and setProcess variable shadowing** (c5e0750d) — call `setMode()` before `setDevice()/setProcess()` so mode defaults land first; rename local `process` to `procset` to avoid shadowing Node's global `process` (was silently breaking `process.exit`/`stderr` under ESM)
3. **fix: WASM path resolution, process variable fix, document CAM limitation** (cca1decd) — intercept `fs.readFileSync` to redirect `.wasm` lookups to `src/wasm/` so `manifold-3d` loads correctly; suppress `Aborted()` exceptions cleanly from optional WASM modules; explicitly set `controller.threaded:false` after `setMode` to prevent the mode switch from re-enabling the pool

## What works

- **FDM, LASER, SLA** modes — all slicing via the in-process Worker bridge. Tested on Raspberry Pi 5 (ARM64) with a cube STL + Ender 3 FDM config, producing valid gcode.
- Same CLI flags as the original (`--model`, `--device`, `--process`, `--output`, `--tools`, `--verbose`).
- Clean stdout (gcode pipeable); stderr for diagnostics when `--verbose`.

## What's explicitly deferred

**CAM mode** is documented at the top of `cli.js` as limited. The in-process Worker bridge short-circuits the parallel toolpath pool that CAM relies on. Wiring CAM up properly needs Node's `worker_threads` behind the same `globalThis.Worker` shim — meaningful scope best handled as a follow-up PR so this one stays reviewable.

The CAM config templates (`src/cli/kiri-cam-{device,process,tools}.json`) are kept in-tree so the follow-up can focus on just the worker pool.

## Testing

Run any of:

```bash
node src/kiri/run/cli.js \
  --model your.stl \
  --device src/cli/kiri-fdm-device.json \
  --process src/cli/kiri-fdm-process.json \
  --output out.gcode
```

Or the LASER/SLA equivalents with matching device/process JSON. Works on Node 22 (Docker image and host).

## Platform notes

- Tested on ARM64 (Raspberry Pi 5) and x86_64.
- Needs the esbuild bundles present (`npm run pack-prod` after install) — #478 ensures the Dockerfile does this automatically.