### PR TITLE
fix: correct G4 dwell time in Makera Carvera Air spindle config (seconds, not ms)

### DIFF
--- a/src/kiri/dev/cam/Makera.Carvera.Air.json
+++ b/src/kiri/dev/cam/Makera.Carvera.Air.json
@@ -23,7 +23,7 @@
     ],
     "gcodeSpindle": [
         "M3 S{spindle}",
-        "G4 P4000"
+        "G4 P4"
     ],
     "gcodeChange": [
         "M6 T{tool} ; change tool to '{tool_name}'"


### PR DESCRIPTION
## Summary

- In `gcodeSpindle` for the Makera Carvera Air device profile, the `G4 P4000` command was using an incorrect value.
- The `G4 P` parameter is in **seconds** (per G-code standard), so `P4000` would cause a 4000-second (over an hour) dwell after spindle start.
- Changed to `G4 P4` for the intended 4-second spin-up delay.

## Change

`src/kiri/dev/cam/Makera.Carvera.Air.json`

```diff
-        "G4 P4000"
+        "G4 P4"
```

## Test plan

- [ ] Verify generated G-code for Makera Carvera Air uses `G4 P4` after spindle start (`M3 S{spindle}`)
- [ ] Confirm spindle spins up for ~4 seconds before cutting begins

🤖 Generated with [Claude Code](https://claude.com/claude-code)