### PR TITLE
expose stock Z as const to be used in custom GCode

### DIFF
--- a/docs/kiri-moto/gcode-macros.md
+++ b/docs/kiri-moto/gcode-macros.md
@@ -83,6 +83,7 @@ Allows for intro comment and config list to be re-positioned after the header or
 - \{pos_x\} = last output X position
 - \{pos_y\} = last output Y position
 - \{pos_z\} = last output Z position
+- \{stock_z\} = max stock volume height in mm
 
 ### CAM Header Directives
 

--- a/src/kiri/mode/cam/work/export.js
+++ b/src/kiri/mode/cam/work/export.js
@@ -76,7 +76,8 @@ export function cam_export(print, online) {
             bottom: (offset ? 0 : -dev.bedDepth / 2),
             time_sec: 0,
             time_ms: 0,
-            time: 0
+            time: 0,
+            stock_z: stock.z
         };
 
     // console.log({ offset, origin, stock });


### PR DESCRIPTION
Max height can be useful when customising device GCode (for example, to manually calibrate the top layer).

The name could be change to something more convenient.
