### PR TITLE
Fix a bug in CAM generation which can cause diagonal gouging

### DIFF
--- a/src/kiri/mode/cam/work/prepare.js
+++ b/src/kiri/mode/cam/work/prepare.js
@@ -608,9 +608,9 @@ export async function prepare_one(widget, settings, print, firstPoint, update) {
                 }
             }
             lastTravelBounds = undefined;
-        } else
+        }
         // for longer moves
-        if (isMove) {
+        if (isMove && !upAndOver) {
             const bigXY = (deltaXY > shortCut && !lasering);
             const bigZ  = (absDeltaZ > toolDiam / 2 && deltaXY > tolerance);
             const midZ  = (tolerance && absDeltaZ >= tolerance);


### PR DESCRIPTION
If `hasBounds` is `true` but the requested move is within those bounds (all projected into the XY plane), the secondary check for "big moves intersecting stock" is never done. This can lead to diagonal gouges (for example, between ops).


*I identified this problem using AI tools while I was working on a larger PR, but since this is a bugfix independent of my side project, I figured I'd submit it as its own PR*