### PR TITLE
fix: skip CAM ease-down for features barely larger than the cutter

### DIFF
--- a/src/kiri/mode/cam/work/prepare.js
+++ b/src/kiri/mode/cam/work/prepare.js
@@ -863,8 +863,14 @@ export async function prepare_one(widget, settings, print, firstPoint, update) {
             // so we need to translate printPoint into widget coordinates
             let startPoint = printPoint.clone().move({ x: -wmx, y: -wmy, z: -wmz });
 
+            // a feature barely larger than the cutter leaves a round residual
+            // loop only a fraction of the tool diameter across. easing around
+            // it is no gentler than plunging straight down, so skip it
+            let easeUseless = poly.circularity() > 0.9 &&
+                poly.perimeter() / Math.PI < toolDiam * 0.1;
+
             // calculate ease down for poly path output
-            if (startPoint.z > point0.z) {
+            if (startPoint.z > point0.z && !easeUseless) {
                 let easeMax = feedRate * camFullEngage;
                 let easeLerp = plungeRate + ((feedRate - plungeRate) * easeThrottle);
                 let easeFeed = Math.min(easeLerp, easeMax);


### PR DESCRIPTION
### Symptom

With ease-down enabled, any CAM feature whose size is close to the cutter diameter produces a huge number of useless sub-micron `G1` moves, and the ramp itself accomplishes nothing — the tool still plunges straight down for almost the entire depth.

On a real part with 8 such holes this produced **36,518 wasted `G1` moves — 96% of a 45,352-line G-code file**. The median segment length across the whole file was 0.0006 mm. Beyond file size, thousands of consecutive sub-micron moves starve controller look-ahead and cause visible stuttering.

### Root cause

Offsetting a hole inward by the tool radius leaves a residual toolpath loop only microns across when the hole is close to the tool diameter. `polyEmit()` then ramps around that tiny loop, bounded only by the 50-lap safeguard added in 4.6.1 ("add ease down safeguards for bad geometry"):

```js
// hard cap on number of repeats to catch bad geometry
for (let i=0; i<len*50 ; i++) {
```

The cap stops runaway looping, but the ramp still burns its entire budget before the normal emit path plunges straight down for the remainder.

### Measured repro

Kiri:Moto 4.6.1, 6.35 mm endmill, ~6.356 mm hole, `camEaseAngle` 40, 0.8 mm per-pass depth:

| | |
|---|---|
| residual toolpath loop | 6.1 µm across, ~46 points, perimeter 0.0192 mm |
| descent required | 12.2 mm |
| descent per lap | `0.0192 * tan(40°)` = 0.0161 mm |
| after 50 laps | 0.805 mm — **6.6%** of what is needed |
| moves emitted | 2,291 (= 50 × 46, the full cap) |
| then | one `G1 Z` move plunges the remaining 11.4 mm |

### The fix

Ease-down is functionally useless on such a path in the first place: a helix a fraction of the tool diameter wide is no gentler on the cutter than a straight plunge, since the cutter is engaged across its whole face either way. So rather than trying to make the ramp fit, detect the case and disable ease-down for that closed path.

The test uses the tool diameter and the polygon's `circularity()`:

```js
// a feature barely larger than the cutter leaves a round residual
// loop only a fraction of the tool diameter across. easing around
// it is no gentler than plunging straight down, so skip it
let easeUseless = poly.circularity() > 0.9 &&
    poly.perimeter() / Math.PI < toolDiam * 0.1;
```

`circularity()` (1.0 = perfect circle) confirms the path is a round remnant, which is what makes `perimeter / π` a meaningful diameter for it. The threshold skips ease-down when the residual loop is under 10% of the tool diameter — i.e. a hole under about 1.1× the cutter diameter.

The guard is on the **inner** `if (startPoint.z > point0.z)`, not the outer `if (!contouring && camEaseDown && poly.isClosed())` — that outer block also performs the "up and over" positioning move and the `setContouring(true/false)` pair, which must still run.

Net diff is +7/−1 in one hunk. The existing 50-lap cap is left exactly as it was.

### Verification

Measured with the actual `Polygon` class (`circularity()`, `perimeter()`), tool diameter 6.35 mm:

| path | circularity | loop Ø | % of tool | result |
|---|---|---|---|---|
| repro residual loop (6.1 µm, 46 pts) | 0.9984 | 0.0061 mm | 0.10% | **skip** |
| 6.9 mm hole | 0.9991 | 0.550 mm | 8.66% | **skip** |
| 7 mm hole | 0.9991 | 0.650 mm | 10.2% | ramp |
| 8 mm hole | 0.9991 | 1.649 mm | 26.0% | ramp |
| 12 mm hole | 0.9998 | 5.649 mm | 89.0% | ramp |
| 100 mm outer profile | 0.7854 | — | — | ramp |

The threshold sits comfortably inside the region where the ramp still works: at exactly 10% of tool diameter, a 12.2 mm descent needs 7.1 laps at a 40° ease angle, or 34.7 laps at the default 10° — both within the existing 50-lap cap. So the two safeguards agree rather than overlapping awkwardly.

`Polygon.perimeter()` and `Polygon.area()` are both memoized, so the check is cheap. Arc detection only annotates points and does not change geometry, so the test gives the same answer on the arc-detected poly.

When ease-down is skipped, `points` is not rotated — matching the existing `startPoint.z <= point0.z` path, so no new behavior is introduced.

### Known gaps

- The circularity gate means a tiny **non-round** remnant (e.g. a small square pocket, circularity 0.785) is not caught and still relies on the existing 50-lap cap. Round holes are the reported and by far the common case; happy to widen this if you'd rather.
- At the extreme low end of `camEaseAngle` (bounded at 0.1°), a path just above the diameter threshold can still exhaust the lap cap. That is the pre-existing safeguard behaving as designed for an extreme setting, and is unchanged by this PR.

### Not included

No version bump, and no changes to bundled or generated output.

---

*Previous revision of this PR gated on whether the ramp could reach depth within the 50-lap budget. Replaced per maintainer feedback with the tool-diameter/circularity test above, which is simpler and addresses the actual reason the ramp is pointless here.*
