### PR TITLE
Deep-copy the cached shadow array to prevent corruption

### DIFF
--- a/src/geo/polygon.js
+++ b/src/geo/polygon.js
@@ -551,7 +551,11 @@ export class Polygon {
             ln = this.length,
             i = 0;
 
-        while (i < ln) np.push(this.points[i++]);
+        if (deep) {
+            while (i < ln) np.push(this.points[i++].clone());
+        } else {
+            while (i < ln) np.push(this.points[i++]);
+        }
 
         fields && fields.forEach(field => np[field] = this[field]);
         this.fillang && (np.fillang = this.fillang);
@@ -559,7 +563,7 @@ export class Polygon {
         np.open = this.open;
 
         if (deep && this.inner) {
-            np.inner = this.inner.clone(false, fields);
+            np.inner = this.inner.clone(true, fields);
         }
 
         return np;

--- a/src/kiri/core/widget.js
+++ b/src/kiri/core/widget.js
@@ -751,6 +751,9 @@ class Widget {
                 }
             }
         }
+        // clone shadow array/polygons/points to prevent subsequent setZ mutations
+        // from modifying cached polygons and shared state.shadow.base references.
+        shadow = shadow.clone(true);
         return shadows[z] = POLY.setZ(shadow, z);
     }
 


### PR DESCRIPTION
I noticed that when I had a part with a roughing operation (with 0.5mm stepdown) followed by an outline operation (zero stepdown), the outline op was emitting a `G1 Z0.5005`, putting the tool ~0.5mm above the bottom of the part, rather than a `G1 Z0`.  I investigated (*disclosure: assisted by AI tools*) and found that this was due to the roughing operation corrupting the z values of the global cached shadow array due to it receiving a shallow copy.

This change does two things:
 1. Fix some small bugs in the deep `clone()` codepath in `polygon.js`
 2. Update `shadowAt()` in `widget.js` to deep-copy the cached shadow before returning it


My workspace demonstrating the bug is attached (renamed from `.kmz` to `.zip` to allow github upload)

[workspace_key.zip](https://github.com/user-attachments/files/31523907/workspace_key.zip)
