### PR TITLE
Fix a bug in Point.move()

### DIFF
--- a/src/geo/point.js
+++ b/src/geo/point.js
@@ -863,9 +863,9 @@ class Point {
      * @returns {Point} This point (for chaining)
      */
     move(delta) {
-        this.x += delta.x;
-        this.y += delta.y;
-        this.z += delta.z;
+        this.x += delta.x || 0;
+        this.y += delta.y || 0;
+        this.z += delta.z || 0;
         return this;
     }
 


### PR DESCRIPTION
Update Point.move() to use zero if a delta isn't specified for a given axis

This allows invocations like the ones [here](https://github.com/GridSpace/grid-apps/blob/d41847c4f5319729ee0259acc6c7539b2c16d4ba/src/kiri/mode/cam/work/prepare.js#L566-L567) to work successfully, rather than setting the value of coordinates without a specified delta to `NaN`.

Before:

```js
let p = newPoint(0, 0, 0);
p.move({z: 1});
console.log(p); // prints {x: NaN, y: NaN, z: 1}
```

After:

```js
let p = newPoint(0, 0, 0);
p.move({z: 1});
console.log(p); // prints {x: 0, y: 0, z: 1}
```