### PR TITLE
Fix two related travel move bugs

### DIFF
--- a/src/kiri/mode/cam/work/prepare.js
+++ b/src/kiri/mode/cam/work/prepare.js
@@ -584,9 +584,14 @@ export async function prepare_one(widget, settings, print, firstPoint, update) {
                 emit = 1;
             } else
             // otherwise move over before descending
-            if (deltaZ <= -tolerance) {
-                if (debug) console.log('over before descend', deltaZ, -tolerance);
-                layerPush(point.clone().setZ(printPoint.z), 0, 0, tool);
+            if (deltaZ < Math.min(-tolerance, -0.001)) {
+                let lift = printPoint.clone();
+                lift.z += 0.1;
+                let target = point.clone();
+                target.z = printPoint.z + 0.1;
+                
+                layerPush(lift, 0, 0, tool);
+                layerPush(target, 0, 0, tool);
                 newLayer();
             }
         } else
@@ -626,6 +631,21 @@ export async function prepare_one(widget, settings, print, firstPoint, update) {
                 }
             }
             lastTravelBounds = undefined;
+
+            // If we are NOT retracting (didn't cross boundaries):
+            if (!upAndOver) {
+                if (deltaZ < Math.min(-tolerance, -0.001)) {
+                    // Descending transition within the pocket -> Z-hop
+                    let lift = printPoint.clone();
+                    lift.z += 0.1;
+                    let target = point.clone();
+                    target.z = printPoint.z + 0.1;
+                    
+                    layerPush(lift, 0, 0, tool);
+                    layerPush(target, 0, 0, tool);
+                    newLayer();
+                }
+            }
         } else
         // for longer moves
         if (isMove) {

--- a/src/kiri/mode/cam/work/prepare.js
+++ b/src/kiri/mode/cam/work/prepare.js
@@ -644,6 +644,15 @@ export async function prepare_one(widget, settings, print, firstPoint, update) {
                     layerPush(lift, 0, 0, tool);
                     layerPush(target, 0, 0, tool);
                     newLayer();
+                } else if (deltaXY <= shortCut && deltaZ <= 0 && !lasering) {
+                    // If this is a short move and the deltaZ failed the check
+                    // in the first branch of this conditional (ie, it's not a
+                    // significant z-descent), but it's still either zero
+                    // (in-plane move) or insignificantly negative, that means
+                    // that we're likely making a cut through stock (a stepover
+                    // cut is the best example of this). Since that's still
+                    // going through material, we force a G1 move for this cut.
+                    emit = 1;
                 }
             }
         } else


### PR DESCRIPTION
Let me know if you want me to separate this out into two PRs for the two bug fixes:

## Bug 1

Update travel moves that are entirely within the part boundary (eg, going from the end of one cutting layer to the beginning of the next) to perform a small (0.1mm) "hop" up, then a rapid in-plane travel, and then finally a rapid move back to the previous z height before starting the plunge move.

Before (large step-down and step-over in order to make the visualization clearer):

<img width="1137" height="815" alt="image" src="https://github.com/user-attachments/assets/d535b4c6-2a71-43d9-b75c-487abeb4db42" />

After:

<img width="1886" height="1069" alt="image" src="https://github.com/user-attachments/assets/af98d45e-d102-42ba-89de-2ce416557865" />

Note that instead of moving at "plunge speed" from the innermost ring of the last layer directly to the outermost ring of the next, we now fast-move up 0.1mm and then over to the plunge point before plunging straight down. (hence the stacked plunge lines on the right side of the screenshot

The code for this is in two different places due to the structure of the nested conditional.


## Bug 2

Moves between concentric offsets in an area clear operation were previously getting omitted as fast moves (`G0`), meaning that we were doing a (relatively short, usually) travel-speed move through uncut material. Notice in the first screenshot how the lines between each concentric circle are blue (travel speed), whereas in the second screenshot they're green (cutting speed). We only force cutting speed if we're making a small move with a zero or insignificant-but-negative Z delta, otherwise we leave it alone.

