### PR TITLE
Retract between non-adjacent in-stock cuts

### DIFF
--- a/src/kiri/mode/cam/work/prepare.js
+++ b/src/kiri/mode/cam/work/prepare.js
@@ -626,6 +626,16 @@ export async function prepare_one(widget, settings, print, firstPoint, update) {
                 }
             }
             lastTravelBounds = undefined;
+
+            // Retract if moving longer distances across stock within pocket bounds
+            if (!upAndOver && deltaXY > shortCut && (camForceZMax || printPoint.z < stockZ || point.z < stockZ)) {
+                // For longer travel moves within bounds that pass below stock height (or if force Z max is set),
+                // trigger an up-and-over retract to zSafe to avoid plowing through uncleared stock at G0.
+                //
+                // A future improvement might add an option for a stepdown-height
+                // Z-hop for in-stock travel moves as an alternative to full zSafe clearance retracts.
+                upAndOver = "in-stock";
+            }
         } else
         // for longer moves
         if (isMove) {


### PR DESCRIPTION
Add a clause to gcode generation which forces a retract when fast-moving between non-adjacent contours in a pocket, even if that move doesn't cross a boundary

Before:

<img width="1489" height="992" alt="image" src="https://github.com/user-attachments/assets/c5d4668b-a6e1-4835-bb62-243220d3d250" />

After:

<img width="1432" height="816" alt="image" src="https://github.com/user-attachments/assets/f1fe4536-f9f4-4155-a5d1-fe3f16e162a6" />


This fix replaces the G0 fast move through stock between the outer perimeter cuts  and the next set of contours (in this case, the rightmost section of the pocket). I broke a few bits on this move before I realized what was happening :upside_down_face: 

Note that this might cause a slight merge conflict with #513 ; if you approve and merge either that one or this one first, I'll update the remaining one to address the conflict.