### PR TITLE
Fix drill operation to respect 'from stock top' setting

### DIFF
--- a/src/kiri/mode/cam/work/op-drill.js
+++ b/src/kiri/mode/cam/work/op-drill.js
@@ -32,12 +32,31 @@ class OpDrill extends CamOp {
             }
 
             let slice = newSlice(0);
-            if (op.mark) {
-                // replace depth with single down peck
-                drill.depth = op.down
+
+            // Determine starting Z top height:
+            // - If 'fromTop' (from stock top) is enabled: start at stock top (settings.stock.z)
+            // - If 'fromTop' is disabled: start at part top (widget.track.top)
+            let stockZ = settings.stock?.z;
+            let partTop = widget?.track?.top;
+            let zTop = drill.z;
+
+            if (op.fromTop && stockZ && stockZ > drill.z) {
+                // Start from stock top when fromTop is selected
+                zTop = stockZ;
+            } else if (!op.fromTop && partTop !== undefined && partTop > drill.z) {
+                // Start from part top when fromTop is deselected
+                zTop = partTop;
             }
 
-            drill.zBottom = drill.z - drill.depth;
+            // Extend plunge depth if starting above the hole's surface Z so plunge reaches target hole bottom
+            let depth = (zTop > drill.z) ? (drill.depth + (zTop - drill.z)) : drill.depth;
+
+            if (op.mark) {
+                // replace depth with single down peck
+                depth = op.down;
+            }
+
+            drill.zBottom = zTop - depth;
 
             // honor zBottom when set
             if (zBottom) drill.zBottom = Math.max(zBottom, drill.zBottom);
@@ -48,7 +67,7 @@ class OpDrill extends CamOp {
             }
 
             const poly = newPolygon()
-            poly.points.push(newPoint(drill.x, drill.y, drill.z))
+            poly.points.push(newPoint(drill.x, drill.y, zTop))
             poly.points.push(newPoint(drill.x, drill.y, drill.zBottom))
 
             slice.camTrace = { tool: op.tool, rate: op.feed, plunge: op.rate };

--- a/src/kiri/mode/cam/work/slice.js
+++ b/src/kiri/mode/cam/work/slice.js
@@ -817,11 +817,6 @@ export async function holes(settings, widget, individual, rec, onProgress) {
         onProgress(0.75 + (i / circles.length * 0.25), "assemble holes");
     }
     drills.forEach(h => {
-        if (rec.fromTop) {
-            // set z top if selected
-            h.depth += wztop - h.z;
-            h.z = wztop;
-        }
         delete h.overlapping; //for encoding
         h.diam = toolDiam; // for mesh generation
         h.selected = (!individual && Math.abs(h.area - area) <= area * 0.05); // for same size selection


### PR DESCRIPTION
The "from stock top" option in the drill operation currently doesn't have any effect on the generated toolpath. This PR fixes that.

Before:

<img width="1078" height="804" alt="image" src="https://github.com/user-attachments/assets/094e50fa-6445-41c3-bb04-9e817f7fa58c" />


After:

<img width="1068" height="872" alt="image" src="https://github.com/user-attachments/assets/3e639224-1f14-4ea3-9ef0-f6e39b33c0b6" />
