### PR TITLE
enforce ForceZMax

### DIFF
--- a/src/kiri/mode/cam/work/prepare.js
+++ b/src/kiri/mode/cam/work/prepare.js
@@ -551,7 +551,10 @@ export async function prepare_one(widget, settings, print, firstPoint, update) {
             isMove = (emit === 0 || emit === false),
             hasBounds = (travelBounds || lastTravelBounds),
             upAndOver = false;
-
+        // propose camForceZMax enforces moves to safeZ
+        if (camForceZMax) {
+            upAndOver = true;
+        } else
         // contouring logic
         if (isMove && contouring) {
             if (coastline && deltaXY < 5 && coastlineMove(point)) {
@@ -636,7 +639,7 @@ export async function prepare_one(widget, settings, print, firstPoint, update) {
             if (bigXY || bigZ || midZ) {
                 if (debug) console.log({ fromz: printPoint.z, toz: point.z });
                 // for big moves intersecting stock...
-                if (camForceZMax || inStock) {
+                if (inStock) {
                     upAndOver = true;
                 }
             }

--- a/src/kiri/mode/cam/work/prepare.js
+++ b/src/kiri/mode/cam/work/prepare.js
@@ -552,7 +552,7 @@ export async function prepare_one(widget, settings, print, firstPoint, update) {
             hasBounds = (travelBounds || lastTravelBounds),
             upAndOver = false;
         // propose camForceZMax enforces moves to safeZ
-        if (camForceZMax) {
+        if (isMove && camForceZMax) {
             upAndOver = true;
         } else
         // contouring logic


### PR DESCRIPTION
This PR targets the camForceZMax setting. This would slightly reinterpret that setting to make any G0 positional moves enforce safeZ when the setting is active. Perhaps more granular changes for the isMove condition will required.